### PR TITLE
more type adapters

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/adapter/BigDecimalAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/BigDecimalAdapter.java
@@ -1,0 +1,20 @@
+package com.github.gfx.android.orma.adapter;
+
+import android.support.annotation.NonNull;
+
+import java.math.BigDecimal;
+
+public class BigDecimalAdapter extends AbstractTypeAdapter<BigDecimal> {
+
+    @NonNull
+    @Override
+    public String serialize(@NonNull BigDecimal source) {
+        return source.toString();
+    }
+
+    @NonNull
+    @Override
+    public BigDecimal deserialize(@NonNull String serialized) {
+        return new BigDecimal(serialized);
+    }
+}

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/BigIntegerAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/BigIntegerAdapter.java
@@ -1,0 +1,20 @@
+package com.github.gfx.android.orma.adapter;
+
+import android.support.annotation.NonNull;
+
+import java.math.BigInteger;
+
+public class BigIntegerAdapter extends AbstractTypeAdapter<BigInteger> {
+
+    @NonNull
+    @Override
+    public String serialize(@NonNull BigInteger source) {
+        return source.toString();
+    }
+
+    @NonNull
+    @Override
+    public BigInteger deserialize(@NonNull String serialized) {
+        return new BigInteger(serialized);
+    }
+}

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/CurrencyAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/CurrencyAdapter.java
@@ -1,0 +1,20 @@
+package com.github.gfx.android.orma.adapter;
+
+import android.support.annotation.NonNull;
+
+import java.util.Currency;
+
+public class CurrencyAdapter extends AbstractTypeAdapter<Currency> {
+
+    @NonNull
+    @Override
+    public String serialize(@NonNull Currency source) {
+        return source.getCurrencyCode();
+    }
+
+    @NonNull
+    @Override
+    public Currency deserialize(@NonNull String serialized) {
+        return Currency.getInstance(serialized);
+    }
+}

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/TypeAdapterRegistry.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/TypeAdapterRegistry.java
@@ -36,6 +36,10 @@ public class TypeAdapterRegistry {
                 new StringSetAdapter(),
                 new UriAdapter(),
                 new DateAdapter(),
+                new UUIDAdapter(),
+                new BigDecimalAdapter(),
+                new BigIntegerAdapter(),
+                new CurrencyAdapter(),
         };
     }
 

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/UUIDAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/UUIDAdapter.java
@@ -1,0 +1,20 @@
+package com.github.gfx.android.orma.adapter;
+
+import android.support.annotation.NonNull;
+
+import java.util.UUID;
+
+public class UUIDAdapter extends AbstractTypeAdapter<UUID> {
+
+    @NonNull
+    @Override
+    public String serialize(@NonNull UUID source) {
+        return source.toString();
+    }
+
+    @NonNull
+    @Override
+    public UUID deserialize(@NonNull String serialized) {
+        return UUID.fromString(serialized);
+    }
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
@@ -38,9 +38,13 @@ import android.database.sqlite.SQLiteException;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Currency;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
@@ -119,6 +123,9 @@ public class ModelSpecTest {
     @Test
     public void testObjectMapping() throws Exception {
         final long now = new Date().getTime();
+        final UUID uuid = UUID.randomUUID();
+        final BigDecimal bd = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
+        final BigInteger bi = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TEN);
 
         System.out.println(db.getConnection().getTypeAdapterRegistry().toString());
         ModelWithTypeAdapters model = db.createModelWithTypeAdapters(new ModelFactory<ModelWithTypeAdapters>() {
@@ -133,6 +140,10 @@ public class ModelSpecTest {
                 model.set.add("baz");
                 model.uri = Uri.parse("http://example.com");
                 model.date = new Date(now);
+                model.uuid = uuid;
+                model.bigDecimal = bd;
+                model.bigInteger = bi;
+                model.currency = Currency.getInstance("JPY");
                 return model;
             }
         });
@@ -141,6 +152,10 @@ public class ModelSpecTest {
         assertThat(model.set, containsInAnyOrder("foo", "bar", "baz"));
         assertThat(model.uri, is(Uri.parse("http://example.com")));
         assertThat(model.date, is(new Date(now)));
+        assertThat(model.uuid, is(uuid));
+        assertThat(model.bigDecimal, is(bd));
+        assertThat(model.bigInteger, is(bi));
+        assertThat(model.currency, is(Currency.getInstance("JPY")));
     }
 
     @Test

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
@@ -22,9 +22,13 @@ import com.github.gfx.android.orma.annotation.Table;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Currency;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 @Table
 public class ModelWithTypeAdapters {
@@ -44,6 +48,18 @@ public class ModelWithTypeAdapters {
     @Column
     public Date date;
 
+    @Column
+    public BigDecimal bigDecimal;
+
+    @Column
+    public BigInteger bigInteger;
+
+    @Column
+    public UUID uuid;
+
+    @Column
+    public Currency currency;
+
     @Nullable
     @Column
     public List<String> nullableList;
@@ -59,5 +75,7 @@ public class ModelWithTypeAdapters {
     @Nullable
     @Column
     public Date nullableDate;
+
+
 
 }


### PR DESCRIPTION
resolve #62 

Now Orma supports currency-related data types: `Currency`, `BigInteger`, and `BigDecimal`.