### PR TITLE
make SchemaDiffMigration more robust

### DIFF
--- a/migration/src/main/java/com/github/gfx/android/orma/migration/SqliteDdlBuilder.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/SqliteDdlBuilder.java
@@ -15,6 +15,8 @@
  */
 package com.github.gfx.android.orma.migration;
 
+import com.github.gfx.android.orma.sqliteparser.SQLiteComponent;
+
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
@@ -43,10 +45,10 @@ public class SqliteDdlBuilder {
     }
 
     @NonNull
-    public String buildCreateTable(@NonNull String table, @NonNull List<String> columns) {
+    public String buildCreateTable(@NonNull SQLiteComponent.Name table, @NonNull List<String> columns) {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE TABLE ");
-        sb.append(ensureQuoted(table));
+        sb.append(table);
         sb.append(" (");
         appendWithSeparator(sb, ", ", columns);
         sb.append(")");
@@ -54,36 +56,35 @@ public class SqliteDdlBuilder {
     }
 
     @NonNull
-    public String buildInsertFromSelect(@NonNull String toTable, @NonNull String fromTable,
-            @NonNull Collection<String> columns) {
+    public String buildInsertFromSelect(@NonNull SQLiteComponent.Name toTable, @NonNull SQLiteComponent.Name fromTable,
+            @NonNull Collection<SQLiteComponent.Name> columns) {
 
         StringBuilder sb = new StringBuilder();
         sb.append("INSERT INTO ");
-        sb.append(ensureQuoted(toTable));
+        sb.append(toTable);
         sb.append(" (");
-        String quotedColumns = joinBy(", ", columns, new Func<String, String>() {
-            @Override
-            public String call(String name) {
-                return SqliteDdlBuilder.ensureQuoted(name);
-            }
-        });
-        sb.append(quotedColumns);
+        appendWithSeparator(sb, ", ", columns);
         sb.append(") SELECT ");
-        sb.append(quotedColumns);
+        appendWithSeparator(sb, ", ", columns);
         sb.append(" FROM ");
-        sb.append(ensureQuoted(fromTable));
+        sb.append(fromTable);
 
         return sb.toString();
     }
 
     @NonNull
-    public String buildDropTable(@NonNull String table) {
-        return "DROP TABLE " + ensureQuoted(table);
+    public String buildDropTable(@NonNull SQLiteComponent.Name table) {
+        return "DROP TABLE " + table;
     }
 
     @NonNull
     public String buildRenameTable(@NonNull String fromTable, @NonNull String toTable) {
-        return "ALTER TABLE " + ensureQuoted(fromTable) + " RENAME TO " + ensureQuoted(toTable);
+        return buildRenameTable(new SQLiteComponent.Name(fromTable), new SQLiteComponent.Name(toTable));
+    }
+
+    @NonNull
+    public String buildRenameTable(@NonNull SQLiteComponent.Name fromTable, @NonNull SQLiteComponent.Name toTable) {
+        return "ALTER TABLE " + fromTable + " RENAME TO " + toTable;
     }
 
     @NonNull
@@ -95,10 +96,10 @@ public class SqliteDdlBuilder {
         return result;
     }
 
-    public void appendWithSeparator(StringBuilder builder, String separator, Collection<?> collection) {
+    public void appendWithSeparator(StringBuilder builder, String separator, Collection<? extends CharSequence> collection) {
         int i = 0;
         int size = collection.size();
-        for (Object item : collection) {
+        for (CharSequence item : collection) {
             builder.append(item);
             if ((i + 1) != size) {
                 builder.append(separator);

--- a/migration/src/test/java/com/github/gfx/android/orma/migration/test/SchemaDiffTest.java
+++ b/migration/src/test/java/com/github/gfx/android/orma/migration/test/SchemaDiffTest.java
@@ -46,7 +46,8 @@ public class SchemaDiffTest {
     static final List<SchemaData> schemas = Arrays.asList(
             new SchemaData("foo", "CREATE TABLE \"foo\" (\"field01\" TEXT, \"field02\" TEXT)",
                     Collections.<String>emptyList()),
-            new SchemaData("bar", "CREATE TABLE \"bar\" (\"field10\" TEXT, \"field20\" TEXT)", Collections.<String>emptyList())
+            new SchemaData("bar", "CREATE TABLE \"bar\" (\"field10\" TEXT, \"field20\" TEXT)",
+                    Collections.<String>emptyList())
     );
 
     static final List<SchemaData> schemasWithIndexes = Arrays.asList(
@@ -56,6 +57,13 @@ public class SchemaDiffTest {
                             "CREATE INDEX \"index_field02_on_foo\" (\"field02\")"
                     )),
             new SchemaData("bar", "CREATE TABLE \"bar\" (\"field10\" TEXT, \"field20\" TEXT)",
+                    Collections.<String>emptyList())
+    );
+
+    static final List<SchemaData> schemasWithDifferentCases = Arrays.asList(
+            new SchemaData("FOO", "CREATE TABLE \"FOO\" (\"FIELD01\" TEXT, \"FIELD02\" TEXT)",
+                    Collections.<String>emptyList()),
+            new SchemaData("BAR", "CREATE TABLE \"BAR\" (\"FIELD10\" TEXT, \"FIELD20\" TEXT)",
                     Collections.<String>emptyList())
     );
 
@@ -119,9 +127,17 @@ public class SchemaDiffTest {
 
         List<String> statements = migration.diffAll(metadata, schemasWithIndexes);
 
-        System.out.println(statements.toString());
-
         assertThat(statements, is(schemasWithIndexes.get(0).getCreateIndexStatements()));
+    }
+
+    @Test
+    public void diffAll_differentCases() throws Exception {
+        Map<String, SQLiteMaster> metadata = migration.loadMetadata(db, schemas);
+
+        List<String> statements = migration.diffAll(metadata, schemasWithDifferentCases);
+
+        assertThat(statements, is(empty()));
+
     }
 
     static class OpenHelper extends SQLiteOpenHelper {

--- a/migration/src/test/java/com/github/gfx/android/orma/migration/test/TableDiffTest.java
+++ b/migration/src/test/java/com/github/gfx/android/orma/migration/test/TableDiffTest.java
@@ -48,7 +48,39 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_reorder() throws Exception {
+    public void same() throws Exception {
+        String a = "CREATE TABLE todo (title TEXT, content TEXT)";
+        String b = "CREATE TABLE todo (title TEXT, content TEXT)";
+        List<String> statements = migration.tableDiff(a, b);
+        assertThat(statements, is(empty()));
+    }
+
+    @Test
+    public void sameButDifferentCases() throws Exception {
+        String a = "CREATE TABLE TODO (TITLE TEXT, CONTENT TEXT)";
+        String b = "create table todo (title text, content text)";
+        List<String> statements = migration.tableDiff(a, b);
+        assertThat(statements, is(empty()));
+    }
+
+    @Test
+    public void sameButAddQuotes() throws Exception {
+        String a = "CREATE TABLE todo (title TEXT, content TEXT)";
+        String b = "CREATE TABLE `todo` (`title` TEXT, `content` TEXT)";
+        List<String> statements = migration.tableDiff(a, b);
+        assertThat(statements, is(empty()));
+    }
+
+    @Test
+    public void sameButRemoveQuotes() throws Exception {
+        String a = "CREATE TABLE `todo` (`title` TEXT, `content` TEXT)";
+        String b = "CREATE TABLE todo (title TEXT, content TEXT)";
+        List<String> statements = migration.tableDiff(a, b);
+        assertThat(statements, is(empty()));
+    }
+
+    @Test
+    public void reorder() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT)";
         String to = "CREATE TABLE todo (content TEXT, title TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -57,7 +89,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_addColumn() throws Exception {
+    public void addOneColumn() throws Exception {
         String from = "CREATE TABLE todo (title TEXT)";
         String to = "CREATE TABLE todo (title TEXT, content TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -70,7 +102,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_addTowColumns() throws Exception {
+    public void addTowColumns() throws Exception {
         String from = "CREATE TABLE todo (title TEXT)";
         String to = "CREATE TABLE todo (title TEXT, content TEXT, createdDate TIMESTAMP)";
         List<String> statements = migration.tableDiff(from, to);
@@ -83,7 +115,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_dropColumn() throws Exception {
+    public void dropOneColumn() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT)";
         String to = "CREATE TABLE todo (title TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -96,7 +128,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_dropTowColumns() throws Exception {
+    public void dropTowColumns() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT, createdDate TIMESTAMP)";
         String to = "CREATE TABLE todo (title TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -110,7 +142,7 @@ public class TableDiffTest {
 
 
     @Test
-    public void tableDiff_addNonNullConstraint() throws Exception {
+    public void addNonNullConstraint() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT)";
         String to = "CREATE TABLE todo (title TEXT, content TEXT NOT NULL)";
         List<String> statements = migration.tableDiff(from, to);
@@ -123,7 +155,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_removeNonNullConstraint() throws Exception {
+    public void removeNonNullConstraint() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT NOT NULL)";
         String to = "CREATE TABLE todo (title TEXT, content TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -136,7 +168,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_addPrimaryKeyConstraint() throws Exception {
+    public void addPrimaryKeyConstraint() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT)";
         String to = "CREATE TABLE todo (title TEXT PRIMARY KEY, content TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -149,7 +181,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_addUniqueConstraint() throws Exception {
+    public void addUniqueConstraint() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT)";
         String to = "CREATE TABLE todo (title TEXT UNIQUE, content TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -162,7 +194,7 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_withQuotedNames() throws Exception {
+    public void withQuotedNames() throws Exception {
         String from = "CREATE TABLE \"todo\" (\"title\" TEXT)";
         String to = "CREATE TABLE \"todo\" (\"title\" TEXT, \"content\" TEXT)";
         List<String> statements = migration.tableDiff(from, to);
@@ -175,9 +207,37 @@ public class TableDiffTest {
     }
 
     @Test
-    public void tableDiff_addConstraints() throws Exception {
+    public void addConstraints() throws Exception {
         String from = "CREATE TABLE todo (title TEXT, content TEXT)";
         String to = "CREATE TABLE todo (title TEXT, content TEXT, UNIQUE(title))";
+        List<String> statements = migration.tableDiff(from, to);
+
+        assertThat(statements, contains(
+                "CREATE TABLE \"__temp_todo\" (\"title\" TEXT, \"content\" TEXT)",
+                "INSERT INTO \"__temp_todo\" (\"title\", \"content\") SELECT \"title\", \"content\" FROM \"todo\"",
+                "DROP TABLE \"todo\"",
+                "ALTER TABLE \"__temp_todo\" RENAME TO \"todo\""
+        ));
+    }
+
+    @Test
+    public void changeTypeFromTextToBlob() throws Exception {
+        String from = "CREATE TABLE todo (title TEXT, content TEXT)";
+        String to = "CREATE TABLE todo (title TEXT, content BLOB)";
+        List<String> statements = migration.tableDiff(from, to);
+
+        assertThat(statements, contains(
+                "CREATE TABLE \"__temp_todo\" (\"title\" TEXT, \"content\" BLOB)",
+                "INSERT INTO \"__temp_todo\" (\"title\", \"content\") SELECT \"title\", \"content\" FROM \"todo\"",
+                "DROP TABLE \"todo\"",
+                "ALTER TABLE \"__temp_todo\" RENAME TO \"todo\""
+        ));
+    }
+
+    @Test
+    public void changeTypeFromBlobToText() throws Exception {
+        String from = "CREATE TABLE todo (title TEXT, content BLOB)";
+        String to = "CREATE TABLE todo (title TEXT, content TEXT)";
         List<String> statements = migration.tableDiff(from, to);
 
         assertThat(statements, contains(

--- a/sqliteparser/build.gradle
+++ b/sqliteparser/build.gradle
@@ -14,7 +14,8 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-    compile 'org.antlr:antlr4-runtime:4.5.1'
+    compile 'com.google.code.findbugs:jsr305:3.0.1'
+    runtime 'org.antlr:antlr4-runtime:4.5.1'
     antlr 'org.antlr:antlr4:4.5.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'

--- a/sqliteparser/src/main/java/com/github/gfx/android/orma/sqliteparser/CreateTableStatement.java
+++ b/sqliteparser/src/main/java/com/github/gfx/android/orma/sqliteparser/CreateTableStatement.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class CreateTableStatement extends SQLiteComponent {
 
-    String tableName;
+    Name tableName;
 
     List<ColumnDef> columns = new ArrayList<>();
 
@@ -33,7 +33,7 @@ public class CreateTableStatement extends SQLiteComponent {
 
     }
 
-    public String getTableName() {
+    public Name getTableName() {
         return tableName;
     }
 
@@ -51,13 +51,13 @@ public class CreateTableStatement extends SQLiteComponent {
 
     public static class ColumnDef extends SQLiteComponent {
 
-        String name;
+        Name name;
 
         String type;
 
         List<Constraint> constraints = new ArrayList<>();
 
-        public String getName() {
+        public Name getName() {
             return name;
         }
 
@@ -93,9 +93,9 @@ public class CreateTableStatement extends SQLiteComponent {
 
     public static class Constraint extends SQLiteComponent {
 
-        String name;
+        Name name;
 
-        public String getName() {
+        public Name getName() {
             return name;
         }
     }

--- a/sqliteparser/src/main/java/com/github/gfx/android/orma/sqliteparser/SQLiteComponent.java
+++ b/sqliteparser/src/main/java/com/github/gfx/android/orma/sqliteparser/SQLiteComponent.java
@@ -18,15 +18,18 @@ package com.github.gfx.android.orma.sqliteparser;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+
+import javax.annotation.Nonnull;
 
 /**
  * Base class of SQLite components
  */
 public class SQLiteComponent {
 
-    protected final List<String> tokens = new ArrayList<>();
+    protected final List<CharSequence> tokens = new ArrayList<>();
 
-    public List<String> getTokens() {
+    public List<CharSequence> getTokens() {
         return tokens;
     }
 
@@ -53,13 +56,100 @@ public class SQLiteComponent {
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        for (String token : tokens) {
-            if (sb.length()!= 0) {
+        for (CharSequence token : tokens) {
+            if (sb.length() != 0) {
                 sb.append(' ');
             }
             sb.append(token);
         }
 
         return sb.toString();
+    }
+
+    public static class CaseInsensitiveToken implements CharSequence {
+
+        @Nonnull
+        final String token;
+
+        public CaseInsensitiveToken(@Nonnull String token) {
+            this.token = token;
+        }
+
+        @Override
+        public int length() {
+            return token.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            return token.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return token.subSequence(start, end);
+        }
+
+        @Nonnull
+        @Override
+        public String toString() {
+            return token;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CaseInsensitiveToken)) {
+                return false;
+            }
+
+            CaseInsensitiveToken that = (CaseInsensitiveToken) o;
+            return token.equalsIgnoreCase(that.token);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return token.toLowerCase(Locale.US).hashCode();
+        }
+    }
+
+    public static class Keyword extends CaseInsensitiveToken {
+
+        public Keyword(@Nonnull String token) {
+            super(token);
+        }
+    }
+
+    public static class Name extends CaseInsensitiveToken {
+
+        public Name(@Nonnull String token) {
+            super(ensureDoubleQuoted(token));
+        }
+
+        @Nonnull
+        public String getUnquotedToken() {
+            return dequote(token);
+        }
+
+        @Nonnull
+        @Override
+        public String toString() {
+            return token;
+        }
+
+        static String ensureDoubleQuoted(String name) {
+            return '"' + dequote(name) + '"';
+        }
+
+        static String dequote(String maybeQuoted) {
+            if (maybeQuoted.charAt(0) == '"' || maybeQuoted.charAt(0) == '`') {
+                return maybeQuoted.substring(1, maybeQuoted.length() - 1);
+            } else {
+                return maybeQuoted;
+            }
+        }
     }
 }

--- a/sqliteparser/src/test/java/com/github/gfx/android/orma/sqliteparser/test/SQLiteComponentTest.java
+++ b/sqliteparser/src/test/java/com/github/gfx/android/orma/sqliteparser/test/SQLiteComponentTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.sqliteparser.test;
+
+import com.github.gfx.android.orma.sqliteparser.SQLiteComponent;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class SQLiteComponentTest {
+
+    @Test
+    public void testKeywordEquals() throws Exception {
+        SQLiteComponent.Keyword a = new SQLiteComponent.Keyword("foo");
+        SQLiteComponent.Keyword b = new SQLiteComponent.Keyword("foo");
+
+        assertThat(a, is(b));
+        assertThat(a.hashCode(), is(b.hashCode()));
+    }
+
+    @Test
+    public void testKeywordCaseInsensitiveEquals() throws Exception {
+        SQLiteComponent.Keyword a = new SQLiteComponent.Keyword("foo");
+        SQLiteComponent.Keyword b = new SQLiteComponent.Keyword("FOO");
+
+        assertThat(a, is(b));
+        assertThat(a.hashCode(), is(b.hashCode()));
+    }
+
+    @Test
+    public void testNameEquals() throws Exception {
+        SQLiteComponent.Name a = new SQLiteComponent.Name("foo");
+        SQLiteComponent.Name b = new SQLiteComponent.Name("foo");
+
+        assertThat(a, is(b));
+        assertThat(a.hashCode(), is(b.hashCode()));
+    }
+
+    @Test
+    public void testNameCaseInsensitiveEquals() throws Exception {
+        SQLiteComponent.Name a = new SQLiteComponent.Name("foo");
+        SQLiteComponent.Name b = new SQLiteComponent.Name("FOO");
+
+        assertThat(a, is(b));
+        assertThat(a.hashCode(), is(b.hashCode()));
+    }
+
+    @Test
+    public void testNameQuoting() throws Exception {
+        SQLiteComponent.Name a = new SQLiteComponent.Name("`foo`");
+        SQLiteComponent.Name b = new SQLiteComponent.Name("\"foo\"");
+
+        assertThat(a, is(b));
+        assertThat(a.hashCode(), is(b.hashCode()));
+
+        assertThat(a.toString(), is("\"foo\""));
+    }
+}

--- a/sqliteparser/src/test/java/com/github/gfx/android/orma/sqliteparser/test/SQLiteParserUtilsTest.java
+++ b/sqliteparser/src/test/java/com/github/gfx/android/orma/sqliteparser/test/SQLiteParserUtilsTest.java
@@ -75,46 +75,46 @@ public class SQLiteParserUtilsTest {
         );
         assertThat(createTableStatement, is(not(nullValue())));
 
-        assertThat(createTableStatement.getTableName(), is("foo"));
+        assertThat(createTableStatement.getTableName(), is(new SQLiteComponent.Name("foo")));
 
         List<CreateTableStatement.ColumnDef> columns = createTableStatement.getColumns();
 
         assertThat(columns, hasSize(3));
         {
             CreateTableStatement.ColumnDef column = columns.get(0);
-            assertThat(column.getName(), is("id"));
+            assertThat(column.getName(), is(new SQLiteComponent.Name("id")));
             assertThat(column.getType(), is("INTEGER"));
 
             List<CreateTableStatement.ColumnDef.Constraint> constraints = column.getConstraints();
             assertThat(constraints, hasSize(1));
             assertThat(constraints.get(0).isPrimaryKey(), is(true));
             assertThat(constraints.get(0).isNullable(), is(false));
-            assertThat(constraints.get(0).getTokens(), contains("PRIMARY", "KEY"));
+            assertThat(constraints.get(0).getTokens(), contains((CharSequence)"PRIMARY", "KEY"));
         }
 
         {
             CreateTableStatement.ColumnDef column = columns.get(1);
-            assertThat(column.getName(), is("title"));
+            assertThat(column.getName(), is(new SQLiteComponent.Name("title")));
             assertThat(column.getType(), is("TEXT"));
             List<CreateTableStatement.ColumnDef.Constraint> constraints = column.getConstraints();
             assertThat(constraints, hasSize(1));
             assertThat(constraints.get(0).isPrimaryKey(), is(false));
             assertThat(constraints.get(0).isNullable(), is(false));
-            assertThat(constraints.get(0).getTokens(), contains("NOT", "NULL", "ON", "CONFLICT", "REPLACE"));
+            assertThat(constraints.get(0).getTokens(), contains((CharSequence)"NOT", "NULL", "ON", "CONFLICT", "REPLACE"));
         }
 
         {
             CreateTableStatement.ColumnDef column = columns.get(2);
-            assertThat(column.getName(), is("price"));
+            assertThat(column.getName(), is(new SQLiteComponent.Name("price")));
             assertThat("ignore size of data types", column.getType(), is("INTEGER UNSIGNED"));
             List<CreateTableStatement.ColumnDef.Constraint> constraints = column.getConstraints();
             assertThat(constraints, hasSize(2));
             assertThat(constraints.get(0).isPrimaryKey(), is(false));
             assertThat(constraints.get(0).isNullable(), is(false));
-            assertThat(constraints.get(0).getTokens(), contains("NOT", "NULL"));
+            assertThat(constraints.get(0).getTokens(), contains((CharSequence)"NOT", "NULL"));
 
             assertThat(constraints.get(1).getDefaultExpr(), is("( 100 * 1.08 )"));
-            assertThat(constraints.get(1).getTokens(), contains("DEFAULT", "(", "100", "*", "1.08", ")"));
+            assertThat(constraints.get(1).getTokens(), contains((CharSequence)"DEFAULT", "(", "100", "*", "1.08", ")"));
         }
     }
 
@@ -129,7 +129,7 @@ public class SQLiteParserUtilsTest {
                         + ")"
         );
 
-        assertThat(createTableStatement.getTableName(), is("foo"));
+        assertThat(createTableStatement.getTableName(), is(new SQLiteComponent.Name("foo")));
         assertThat(createTableStatement.getColumns(), hasSize(2));
 
         assertThat(createTableStatement.getConstraints(), hasSize(2));


### PR DESCRIPTION
* `tableDiff` handles type changes, which was just ignored before
* `tableDIff` ignores cases 