### PR TITLE
Guess getters and setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,9 @@ And `ORDER BY` helpers:
 
 ## Setters and Getters
 
-You can define private columns with `@Getter` and `@Setter`,
+Orma uses getters and setters if their names are inferred.
+
+You can also connect getters and setters with `@Getter` and `@Setter` respectively,
 which tells `orma-processor` to use accessors.
 
 Each accessor name can specify a column name in SQLite database,

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithAccessors.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithAccessors.java
@@ -47,6 +47,9 @@ public class ModelWithAccessors {
     @Nullable // Boolean is a kind of boolean
     private Boolean done;
 
+    @Column // without @Getter and @Setter annotations
+    private long order;
+
     @Getter(kId)
     public long getId() {
         return id;
@@ -96,5 +99,13 @@ public class ModelWithAccessors {
     @Setter
     public void setDone(@Nullable Boolean done) {
         this.done = done;
+    }
+
+    public long getOrder() {
+        return order;
+    }
+
+    public void setOrder(long order) {
+        this.order = order;
     }
 }

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/ColumnDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/ColumnDefinition.java
@@ -66,9 +66,9 @@ public class ColumnDefinition {
 
     public final Column.Collate collate;
 
-    public Element getter;
+    public ExecutableElement getter;
 
-    public Element setter;
+    public ExecutableElement setter;
 
     public ColumnDefinition(SchemaDefinition schema, VariableElement element) {
         this.schema = schema;
@@ -168,6 +168,15 @@ public class ColumnDefinition {
             }
         }
         return false;
+    }
+
+    public void initGetterAndSetter(ExecutableElement getter, ExecutableElement setter) {
+        if (getter != null) {
+            this.getter = getter;
+        }
+        if (setter != null) {
+            this.setter = setter;
+        }
     }
 
     public AssociationDefinition getAssociation() {


### PR DESCRIPTION
Kotlin classes define getters and setters for their properties, so Java code can't access their raw fields.

This PR makes Orma to use getters and setters even if they are not annotated by `@Getter` and `@Setter` to use Kotlin classes as Orma models.