### PR TITLE
add OrmaConfiguration#tryParsingSql() to omit parsing SQL in setup

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConfiguration.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConfiguration.java
@@ -49,6 +49,8 @@ public abstract class OrmaConfiguration<T extends OrmaConfiguration<?>> {
 
     boolean trace;
 
+    boolean tryParsingSql;
+
     AccessThreadConstraint readOnMainThread;
 
     AccessThreadConstraint writeOnMainThread;
@@ -61,6 +63,7 @@ public abstract class OrmaConfiguration<T extends OrmaConfiguration<?>> {
         // debug flags
 
         trace = debug;
+        tryParsingSql = debug;
 
         if (debug) {
             readOnMainThread = AccessThreadConstraint.WARNING;
@@ -114,6 +117,11 @@ public abstract class OrmaConfiguration<T extends OrmaConfiguration<?>> {
     public T foreignKeys(boolean foreignKeys) {
         this.foreignKeys = foreignKeys;
         return (T) this;
+    }
+
+    public T tryParsingSql(boolean tryParsingSql) {
+        this.tryParsingSql = tryParsingSql;
+        return (T)this;
     }
 
     /**

--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
@@ -61,7 +61,7 @@ public class OrmaConnection extends SQLiteOpenHelper {
 
     final boolean foreignKeys;
 
-    final boolean debug;
+    final boolean tryParsingSql;
 
     final boolean trace;
 
@@ -79,7 +79,7 @@ public class OrmaConnection extends SQLiteOpenHelper {
         this.wal = configuration.wal;
         this.typeAdapterRegistry = configuration.typeAdapterRegistry;
 
-        this.debug = configuration.debug;
+        this.tryParsingSql = configuration.tryParsingSql;
         this.trace = configuration.trace;
         this.readOnMainThread = configuration.readOnMainThread;
         this.writeOnMainThread = configuration.readOnMainThread;
@@ -291,7 +291,7 @@ public class OrmaConnection extends SQLiteOpenHelper {
 
     void createAllTables(SQLiteDatabase db) {
         for (Schema<?> schema : schemas) {
-            if (debug) {
+            if (tryParsingSql) {
                 SQLiteParserUtils.parse(schema.getCreateTableStatement());
             }
             execSQL(db, schema.getCreateTableStatement());

--- a/library/src/test/java/com/github/gfx/android/orma/test/ConditionHelpersTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ConditionHelpersTest.java
@@ -41,15 +41,9 @@ public class ConditionHelpersTest {
 
     OrmaDatabase db;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        db = OrmaDatabase.builder(getContext())
-                .name(null)
-                .build();
+        db = OrmaBuilder.create();
 
         db.transactionSync(new TransactionTask() {
             @Override

--- a/library/src/test/java/com/github/gfx/android/orma/test/ForeignKeysTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ForeignKeysTest.java
@@ -26,10 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.content.Context;
 import android.database.sqlite.SQLiteException;
 import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.*;
@@ -42,13 +40,9 @@ public class ForeignKeysTest {
 
     Publisher publisher;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        db = OrmaDatabase.builder(getContext()).name(null).build();
+        db = OrmaBuilder.create();
 
         publisher = db.createPublisher(new ModelFactory<Publisher>() {
             @NonNull

--- a/library/src/test/java/com/github/gfx/android/orma/test/MigrationEngineTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/MigrationEngineTest.java
@@ -45,6 +45,7 @@ public class MigrationEngineTest {
         conn = OrmaDatabase.builder(getContext())
                 .name(null)
                 .migrationEngine(migration)
+                .tryParsingSql(false)
                 .build()
                 .getConnection();
     }

--- a/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
@@ -30,11 +30,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.content.Context;
 import android.database.sqlite.SQLiteException;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import java.math.BigDecimal;
@@ -53,16 +51,9 @@ public class ModelSpecTest {
 
     OrmaDatabase db;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        db = OrmaDatabase.builder(getContext())
-                .name(null)
-                .trace(true)
-                .build();
+        db = OrmaBuilder.create();
     }
 
     @Test

--- a/library/src/test/java/com/github/gfx/android/orma/test/OrmaAdapterDelegateTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/OrmaAdapterDelegateTest.java
@@ -46,9 +46,7 @@ public class OrmaAdapterDelegateTest {
 
     @Before
     public void setUp() throws Exception {
-        OrmaDatabase orma = OrmaDatabase.builder(getContext())
-                .name(null)
-                .build();
+        OrmaDatabase orma = OrmaBuilder.create();
 
         Inserter<Author> inserter = orma.prepareInsertIntoAuthor();
         inserter.execute(new ModelFactory<Author>() {

--- a/library/src/test/java/com/github/gfx/android/orma/test/OrmaBuilder.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/OrmaBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test;
+
+import com.github.gfx.android.orma.test.model.OrmaDatabase;
+
+import android.support.test.InstrumentationRegistry;
+
+public class OrmaBuilder {
+
+    public static OrmaDatabase create() {
+        return OrmaDatabase.builder(InstrumentationRegistry.getTargetContext())
+                .name(null)
+                .tryParsingSql(false)
+                .build();
+    }
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/OrmaDatabaseTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/OrmaDatabaseTest.java
@@ -55,6 +55,7 @@ public class OrmaDatabaseTest {
                 .typeAdapters(new UriAdapter(), new DateAdapter())
                 .readOnMainThread(AccessThreadConstraint.NONE)
                 .writeOnMainThread(AccessThreadConstraint.NONE)
+                .tryParsingSql(false)
                 .trace(true)
                 .build();
 
@@ -69,6 +70,7 @@ public class OrmaDatabaseTest {
         OrmaDatabase db = OrmaDatabase.builder(getContext())
                 .name(NAME)
                 .writeAheadLogging(true)
+                .tryParsingSql(false)
                 .build();
 
         assertThat(db.getConnection().getReadableDatabase().isWriteAheadLoggingEnabled(), is(true));
@@ -80,6 +82,7 @@ public class OrmaDatabaseTest {
         OrmaDatabase db = OrmaDatabase.builder(getContext())
                 .name(NAME)
                 .writeAheadLogging(false)
+                .tryParsingSql(false)
                 .build();
 
         assertThat(db.getConnection().getReadableDatabase().isWriteAheadLoggingEnabled(), is(false));

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
@@ -34,11 +34,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
 import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import java.util.ArrayList;
@@ -61,13 +59,9 @@ public class QueryTest {
 
     Publisher publisher;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        db = OrmaDatabase.builder(getContext()).name(null).build();
+        db = OrmaBuilder.create();
 
         publisher = db.createPublisher(new ModelFactory<Publisher>() {
             @NonNull

--- a/library/src/test/java/com/github/gfx/android/orma/test/RelationTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/RelationTest.java
@@ -29,8 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.*;
@@ -41,16 +39,9 @@ public class RelationTest {
 
     OrmaDatabase orma;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        orma = OrmaDatabase.builder(getContext())
-                .trace(true)
-                .name(null)
-                .build();
+        orma = OrmaBuilder.create();
 
         Inserter<Author> inserter = orma.prepareInsertIntoAuthor();
         inserter.execute(new ModelFactory<Author>() {

--- a/library/src/test/java/com/github/gfx/android/orma/test/ReservedWordsTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ReservedWordsTest.java
@@ -22,8 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.*;
@@ -34,13 +32,9 @@ public class ReservedWordsTest {
 
     OrmaDatabase db;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        db = OrmaDatabase.builder(getContext()).name(null).build();
+        db = OrmaBuilder.create();
     }
 
     @Test

--- a/library/src/test/java/com/github/gfx/android/orma/test/RxObservableTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/RxObservableTest.java
@@ -25,9 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import java.util.List;
@@ -42,13 +40,9 @@ public class RxObservableTest {
 
     Publisher publisher;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        db = OrmaDatabase.builder(getContext()).name(null).build();
+        db = OrmaBuilder.create();
 
         publisher = db.createPublisher(new ModelFactory<Publisher>() {
             @NonNull

--- a/library/src/test/java/com/github/gfx/android/orma/test/SetterAndGetterTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/SetterAndGetterTest.java
@@ -25,9 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.*;
@@ -38,15 +36,9 @@ public class SetterAndGetterTest {
 
     OrmaDatabase db;
 
-    Context getContext() {
-        return InstrumentationRegistry.getTargetContext();
-    }
-
     @Before
     public void setUp() throws Exception {
-        db = OrmaDatabase.builder(getContext())
-                .name(null)
-                .build();
+        db = OrmaBuilder.create();
     }
 
     @Test

--- a/migration/src/main/java/com/github/gfx/android/orma/migration/sqliteparser/SQLiteParserUtils.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/sqliteparser/SQLiteParserUtils.java
@@ -43,7 +43,11 @@ public class SQLiteParserUtils {
 
     public static SQLiteParser.ParseContext parse(String sql) throws ParseCancellationException {
         SQLiteParser parser = createParser(sql);
-        return parser.parse();
+        try {
+            return parser.parse();
+        } catch (StackOverflowError e) {
+            throw new ParseCancellationException("SQL is too complex to parse: " + sql, e);
+        }
     }
 
     public static CreateTableStatement parseIntoCreateTableStatement(String sql) throws ParseCancellationException {


### PR DESCRIPTION
This is because the current tests includes "too complex SQL"s (related to #99).