### PR TITLE
fix crash with proguard; because of missing proguard configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ build/
 captures/
 .gradletasknamecache
 
+# gh-pages
+_site/
+
 # gradlew's bug?
 true

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -16,8 +16,12 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {

--- a/example/proguard-rules.pro
+++ b/example/proguard-rules.pro
@@ -1,17 +1,31 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /usr/local/opt/android-sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# Add any project specific keep options here:
+# To make debug easier
+-keepattributes SourceFile,LineNumberTable
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# RxJava
+-dontwarn rx.internal.util.unsafe.**
+-keep class rx.schedulers.Schedulers {
+    public static <methods>;
+}
+-keep class rx.schedulers.ImmediateScheduler {
+    public <methods>;
+}
+-keep class rx.schedulers.TestScheduler {
+    public <methods>;
+}
+-keep class rx.schedulers.Schedulers {
+    public static ** test();
+}
+
+# Realm
+-keep class io.realm.annotations.RealmModule
+-keep @io.realm.annotations.RealmModule class *
+-keep class io.realm.internal.Keep
+-keep @io.realm.internal.Keep class * { *; }
+-dontwarn javax.**
+-dontwarn io.realm.**
+
+# Android Support Library
+-keep class android.support.**

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -12,6 +12,8 @@ android {
         versionCode 1
         versionName rootProject.ext.metadata.version
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        consumerProguardFiles 'proguard-rules.pro'
     }
     buildTypes {
         release {

--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -1,0 +1,8 @@
+# ProGuard configuration for Orma
+
+# to use ParameterizedType
+-keepattributes Signature
+
+# Antlr4
+-dontwarn org.antlr.v4.runtime.misc.**
+

--- a/library/src/main/java/com/github/gfx/android/orma/internal/TypeHolder.java
+++ b/library/src/main/java/com/github/gfx/android/orma/internal/TypeHolder.java
@@ -27,9 +27,15 @@ import java.lang.reflect.Type;
 @SuppressWarnings("unused")
 public abstract class TypeHolder<T> {
 
+
     public Type getType() {
         Class<?> c = getClass();
-        ParameterizedType t = (ParameterizedType) c.getGenericSuperclass();
+        ParameterizedType t;
+        try {
+            t = (ParameterizedType) c.getGenericSuperclass();
+        } catch (ClassCastException e) {
+            throw new RuntimeException("No type signature found. Missing -keepattributes Signature in progurad-rules.pro?", e);
+        }
         return EquatableTypeWrapper.wrap(t.getActualTypeArguments()[0]);
     }
 }


### PR DESCRIPTION
Orma requires `-keepattributes Signature` for ProGuard.

This PR uses `consumerProguardFiles` to bundle a proguard configuration file in AAR.