### PR TITLE
deprecate OrmaConnection#getTypeAdapterRegistry()

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
@@ -138,6 +138,7 @@ public class OrmaConnection extends SQLiteOpenHelper {
         return typeAdapterRegistry.get(sourceType);
     }
 
+    @Deprecated // because type adapter registry will become global, static object
     public TypeAdapterRegistry getTypeAdapterRegistry() {
         return typeAdapterRegistry;
     }


### PR DESCRIPTION
That's because type adapter registry will become global, static object.

related to #49 