### PR TITLE
Add OrmaMiration.builder(Context); deprecate old OrmaMigration consractors

### DIFF
--- a/library/src/test/java/com/github/gfx/android/orma/test/MigrationEngineTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/MigrationEngineTest.java
@@ -41,7 +41,10 @@ public class MigrationEngineTest {
 
     @Before
     public void setUp() throws Exception {
-        migration = new OrmaMigration(getContext(), 1, false);
+        migration = OrmaMigration.builder(getContext())
+                .manualStepMigrationVersion(1)
+                .build();
+
         conn = OrmaDatabase.builder(getContext())
                 .name(null)
                 .migrationEngine(migration)

--- a/migration/src/main/java/com/github/gfx/android/orma/migration/ManualStepMigration.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/ManualStepMigration.java
@@ -54,13 +54,17 @@ public class ManualStepMigration implements MigrationEngine {
 
     boolean tableCreated = false;
 
-    public ManualStepMigration(int version, boolean trace) {
+    public ManualStepMigration(int version, SparseArray<Step> steps, boolean trace) {
         this.version = version;
         this.trace = trace;
-        this.steps = new SparseArray<>(0);
+        this.steps = steps.clone();
     }
 
-    public void addStep(int version, @NonNull ManualStepMigration.Step step) {
+    public ManualStepMigration(int version, boolean trace) {
+        this(version, new SparseArray<Step>(0), trace);
+    }
+
+    public void addStep(int version, @NonNull Step step) {
         steps.put(version, step);
     }
 
@@ -89,15 +93,15 @@ public class ManualStepMigration implements MigrationEngine {
 
         int oldVersion = getDbVersion(db);
 
-        Log.v(TAG, "Migration from " + oldVersion + " to " + version);
+        Log.i(TAG, "Migration from " + oldVersion + " to " + version);
 
         if (oldVersion == 0) {
-            Log.v(TAG, "Skip migration because there is no manual migration history");
+            Log.i(TAG, "Skip migration because there is no manual migration history");
             return;
         }
 
         if (oldVersion == version) {
-            Log.v(TAG, "No need to run migration");
+            Log.i(TAG, "No need to run migration");
             return;
         }
 
@@ -124,7 +128,7 @@ public class ManualStepMigration implements MigrationEngine {
             int version = steps.keyAt(i);
             if (oldVersion < version && version <= newVersion) {
                 if (trace) {
-                    Log.v(TAG, "upgrade step #" + version + " from " + oldVersion + " to " + newVersion);
+                    Log.i(TAG, "upgrade step #" + version + " from " + oldVersion + " to " + newVersion);
                 }
                 Step step = steps.valueAt(i);
                 step.up(new Helper(db, version, true));
@@ -141,7 +145,7 @@ public class ManualStepMigration implements MigrationEngine {
             int version = steps.keyAt(i);
             if (newVersion < version && version <= oldVersion) {
                 if (trace) {
-                    Log.v(TAG, "downgrade step #" + version + " from " + oldVersion + " to " + newVersion);
+                    Log.i(TAG, "downgrade step #" + version + " from " + oldVersion + " to " + newVersion);
                 }
                 Step step = steps.valueAt(i);
                 step.down(new Helper(db, version, false));
@@ -160,7 +164,7 @@ public class ManualStepMigration implements MigrationEngine {
 
     public void execStep(SQLiteDatabase db, int version, @Nullable String sql) {
         if (trace) {
-            Log.v(TAG, sql);
+            Log.i(TAG, sql);
         }
         db.execSQL(sql);
         saveStep(db, version, sql);

--- a/migration/src/main/java/com/github/gfx/android/orma/migration/OrmaMigration.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/OrmaMigration.java
@@ -17,30 +17,69 @@ package com.github.gfx.android.orma.migration;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
+import android.util.SparseArray;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
+ * <p>
  * A migration engine that uses both {@link ManualStepMigration} and {@link SchemaDiffMigration}.
+ * </p>
+ * <p>
+ * By default, this class is in auto schema version mode,
+ * where {@code BuildConfig.VERSION_CODE} is used as the {@code schemaVersion} on release build,
+ * or the application updated time is used as the {@code schemaVersion} on debug build.
+ *</p>
+ *
+ * <p>
+ * You can set the schema version manually by {@link OrmaMigration.Builder#schemaVersion(int)}.
+ * </p>
  */
 public class OrmaMigration implements MigrationEngine {
+
+    final int version;
 
     final ManualStepMigration manualStepMigration;
 
     final SchemaDiffMigration schemaDiffMigration;
 
-    public OrmaMigration(@NonNull Context context, int version, boolean trace) {
-        manualStepMigration = new ManualStepMigration(version, trace);
+    public static Builder builder(@NonNull Context context) {
+        return new Builder(context);
+    }
+
+    /**
+     * To control the schema version, use this constructor.
+     *
+     * @param version The database schema version used in {@link android.database.sqlite.SQLiteOpenHelper}.
+     * @param manualStepMigration Used to control manual-step migration
+     * @param schemaDiffMigration Used to control automatic migration
+     */
+    protected OrmaMigration(int version,
+            @NonNull ManualStepMigration manualStepMigration, @NonNull SchemaDiffMigration schemaDiffMigration) {
+        this.version = version;
+        this.manualStepMigration = manualStepMigration;
+        this.schemaDiffMigration = schemaDiffMigration;
+    }
+
+    @Deprecated
+    public OrmaMigration(@NonNull Context context, int versionForManualStepMigration, boolean trace) {
+        manualStepMigration = new ManualStepMigration(versionForManualStepMigration, trace);
         schemaDiffMigration = new SchemaDiffMigration(context, trace);
+        version = schemaDiffMigration.getVersion(); // based on update/install time
     }
 
-    public OrmaMigration(@NonNull Context context, int version) {
-        this(context, version, extractDebuggable(context));
+    @Deprecated
+    public OrmaMigration(@NonNull Context context, int versionForManualStepMigration) {
+        this(context, versionForManualStepMigration, extractDebuggable(context));
     }
 
-    static boolean extractDebuggable(Context context) {
+    protected static boolean extractDebuggable(Context context) {
         return (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)
                 == ApplicationInfo.FLAG_DEBUGGABLE;
     }
@@ -69,7 +108,7 @@ public class OrmaMigration implements MigrationEngine {
      */
     @Override
     public int getVersion() {
-        return schemaDiffMigration.getVersion();
+        return version;
     }
 
     /**
@@ -83,5 +122,98 @@ public class OrmaMigration implements MigrationEngine {
     public void start(@NonNull SQLiteDatabase db, @NonNull List<? extends MigrationSchema> schemas) {
         manualStepMigration.start(db, schemas);
         schemaDiffMigration.start(db, schemas);
+    }
+
+    @NonNull
+    static PackageInfo getPackageInfo(@NonNull Context context) {
+        PackageManager pm = context.getPackageManager();
+        try {
+            return pm.getPackageInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    protected static int extractRevisionByLastUpdateTime(@NonNull Context context) {
+        long milliseconds = getPackageInfo(context).lastUpdateTime;
+        if (milliseconds != 0) {
+            return (int)TimeUnit.MILLISECONDS.toMinutes(milliseconds);
+        } else {
+            return 1; // robolectric;
+        }
+    }
+
+    protected static int extractRevisionByVersionCode(@NonNull  Context context) {
+        int versionCode = getPackageInfo(context).versionCode;
+        if (versionCode != 0) {
+            return versionCode;
+        } else {
+            return 1; // robolectric
+        }
+    }
+
+    public static class Builder {
+
+        final Context context;
+
+        final boolean debug;
+
+        int schemaVersion = 0;
+
+        int manualStepMigrationVersion = 1;
+
+        boolean trace;
+
+        SparseArray<ManualStepMigration.Step> steps = new SparseArray<>();
+
+        Builder(Context context) {
+            this.context = context;
+            debug = extractDebuggable(context);
+            trace = debug;
+            autoSchemaVersion(true);
+        }
+
+        public Builder schemaVersion(@IntRange(from = 1) int version) {
+            schemaVersion = version;
+            return this;
+        }
+
+        public Builder autoSchemaVersion(boolean value) {
+            if (value) {
+                if (debug) {
+                    schemaVersion = extractRevisionByLastUpdateTime(context);
+                } else {
+                    schemaVersion = extractRevisionByVersionCode(context);
+                }
+            } else {
+                schemaVersion = 0;
+            }
+            return this;
+        }
+
+        public Builder manualStepMigrationVersion(@IntRange(from = 1) int version) {
+            manualStepMigrationVersion = version;
+            return this;
+        }
+
+        public Builder trace(boolean value) {
+            trace = value;
+            return this;
+        }
+
+        public Builder step(@IntRange(from = 1) int version, @NonNull ManualStepMigration.Step step) {
+            steps.append(version, step);
+            return this;
+        }
+
+        public OrmaMigration build() {
+            if (schemaVersion == 0) {
+                throw new IllegalArgumentException("no schemaVersion(int) nor autoSchemaVersion(boolean) is supplied");
+            }
+
+            ManualStepMigration manualStepMigration = new ManualStepMigration(manualStepMigrationVersion, steps, trace);
+            SchemaDiffMigration schemaDiffMigration = new SchemaDiffMigration(context, trace);
+            return new OrmaMigration(schemaVersion, manualStepMigration, schemaDiffMigration);
+        }
     }
 }

--- a/migration/src/main/java/com/github/gfx/android/orma/migration/SchemaDiffMigration.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/SchemaDiffMigration.java
@@ -193,9 +193,9 @@ public class SchemaDiffMigration implements MigrationEngine {
                 intersectionColumns.size() != fromTable.getColumns().size() ||
                 !fromTable.getConstraints().equals(toTable.getConstraints())) {
             if (trace) {
-                Log.v(TAG, "tables differ:");
-                Log.v(TAG, "from: " + from);
-                Log.v(TAG, "to:   " + to);
+                Log.i(TAG, "tables differ:");
+                Log.i(TAG, "from: " + from);
+                Log.i(TAG, "to:   " + to);
             }
             return buildRecreateTable(fromTable, toTable, intersectionColumnNames);
         } else {
@@ -261,7 +261,7 @@ public class SchemaDiffMigration implements MigrationEngine {
         try {
             for (String statement : statements) {
                 if (trace) {
-                    Log.v(TAG, statement);
+                    Log.i(TAG, statement);
                 }
                 db.execSQL(statement);
             }

--- a/migration/src/test/java/com/github/gfx/android/orma/migration/test/OrmaMigrationTest.java
+++ b/migration/src/test/java/com/github/gfx/android/orma/migration/test/OrmaMigrationTest.java
@@ -17,6 +17,7 @@ package com.github.gfx.android.orma.migration.test;
 
 import com.github.gfx.android.orma.migration.ManualStepMigration;
 import com.github.gfx.android.orma.migration.OrmaMigration;
+import com.github.gfx.android.orma.migration.SQLiteMaster;
 import com.github.gfx.android.orma.migration.test.util.SchemaData;
 
 import org.junit.Before;
@@ -32,6 +33,10 @@ import android.support.test.runner.AndroidJUnit4;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 
 @RunWith(AndroidJUnit4.class)
 public class OrmaMigrationTest {
@@ -49,8 +54,57 @@ public class OrmaMigrationTest {
     @Before
     public void setUp() throws Exception {
         db = SQLiteDatabase.create(null);
+        db.setVersion(1);
 
-        migration = new OrmaMigration(getContext(), VERSION);
+        migration = OrmaMigration.builder(getContext())
+                .schemaVersion(2)
+                .manualStepMigrationVersion(VERSION)
+                .build();
+
+        migration.getManualStepMigration()
+                .execStep(db, 1, "CREATE TABLE dummy (id INTEGER PRIMARY KEY)");
+    }
+
+    @Test
+    public void testBuilder() throws Exception {
+        migration = OrmaMigration.builder(getContext())
+                .schemaVersion(2)
+                .manualStepMigrationVersion(VERSION)
+                .step(2, new ManualStepMigration.ChangeStep() {
+                    @Override
+                    public void change(@NonNull ManualStepMigration.Helper helper) {
+                        helper.execSQL("CREATE TABLE step_2 (id INTEGER PRIMARY KEY)");
+                    }
+                })
+                .step(4, new ManualStepMigration.ChangeStep() {
+                    @Override
+                    public void change(@NonNull ManualStepMigration.Helper helper) {
+                        helper.execSQL("CREATE TABLE step_4 (id INTEGER PRIMARY KEY)");
+                    }
+                })
+                .step(8, new ManualStepMigration.ChangeStep() {
+                    @Override
+                    public void change(@NonNull ManualStepMigration.Helper helper) {
+                        helper.execSQL("CREATE TABLE step_8 (id INTEGER PRIMARY KEY)");
+                    }
+                })
+                .step(16, new ManualStepMigration.ChangeStep() {
+                    @Override
+                    public void change(@NonNull ManualStepMigration.Helper helper) {
+                        helper.execSQL("CREATE TABLE step_16 (id INTEGER PRIMARY KEY)");
+                    }
+                })
+                .build();
+
+        migration.start(db, new ArrayList<SchemaData>());
+        migration.start(db, new ArrayList<SchemaData>());
+        migration.start(db, new ArrayList<SchemaData>());
+
+        Map<String, SQLiteMaster> tables = SQLiteMaster.loadTables(db);
+        assertThat(tables.containsKey("step_2"), is(true));
+        assertThat(tables.containsKey("step_4"), is(true));
+        assertThat(tables.containsKey("step_8"), is(true));
+        assertThat(tables.containsKey("step_16"), is(true));
     }
 
     @Test
@@ -84,6 +138,12 @@ public class OrmaMigrationTest {
         migration.start(db, new ArrayList<SchemaData>());
         migration.start(db, new ArrayList<SchemaData>());
         migration.start(db, new ArrayList<SchemaData>());
+
+        Map<String, SQLiteMaster> tables = SQLiteMaster.loadTables(db);
+        assertThat(tables.containsKey("step_2"), is(true));
+        assertThat(tables.containsKey("step_4"), is(true));
+        assertThat(tables.containsKey("step_8"), is(true));
+        assertThat(tables.containsKey("step_16"), is(true));
     }
 
     @Test
@@ -98,7 +158,7 @@ public class OrmaMigrationTest {
         };
 
         for (String s : initData) {
-            migration.getManualStepMigration().execStep(db, 1, s);
+            migration.getManualStepMigration().execStep(db, 2, s);
         }
 
         // define steps
@@ -117,5 +177,9 @@ public class OrmaMigrationTest {
 
         // start migration
         migration.start(db, schemas);
+
+        Map<String, SQLiteMaster> tables = SQLiteMaster.loadTables(db);
+        assertThat(tables.get("foo").sql, is(schemas.get(0).getCreateTableStatement()));
+        assertThat(tables.get("bar").sql, is(schemas.get(1).getCreateTableStatement()));
     }
 }


### PR DESCRIPTION
`ApplicationInfo#lastUpdateTime` is not reliable because users can change device time easily. That is, the `lastUpdateTime` based migration trigger might not be reliable, neither.

A newly introduced class, `OrmaMigration.Builder` supports `autoSchemaVersion` mode where `VERSION_CODE` is used on release build, while `lastUpdateTime` is used on debug build.

See `OrmaMigrationTest#testBuilder()` for details.