### PR TITLE
make SchemaDiffMigration to use versioning which is the same logic as OrmaMigration

### DIFF
--- a/migration/src/main/java/com/github/gfx/android/orma/migration/AbstractMigrationEngine.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/AbstractMigrationEngine.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.migration;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractMigrationEngine implements MigrationEngine {
+
+    protected final int version;
+
+    public AbstractMigrationEngine(@IntRange(from = 1) int version) {
+        this.version = version;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    protected static boolean extractDebuggable(Context context) {
+        return (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)
+                == ApplicationInfo.FLAG_DEBUGGABLE;
+    }
+
+    @NonNull
+    protected static PackageInfo getPackageInfo(@NonNull Context context) {
+        PackageManager pm = context.getPackageManager();
+        try {
+            return pm.getPackageInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    protected static int extractLastUpdateTime(@NonNull Context context) {
+        long milliseconds = getPackageInfo(context).lastUpdateTime;
+        if (milliseconds != 0) {
+            return (int) TimeUnit.MILLISECONDS.toMinutes(milliseconds);
+        } else {
+            return 1; // robolectric;
+        }
+    }
+
+    protected static int extractVersionCode(@NonNull  Context context) {
+        int versionCode = getPackageInfo(context).versionCode;
+        if (versionCode != 0) {
+            return versionCode;
+        } else {
+            return 1; // robolectric
+        }
+    }
+
+}

--- a/migration/src/main/java/com/github/gfx/android/orma/migration/ManualStepMigration.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/ManualStepMigration.java
@@ -27,7 +27,7 @@ import android.util.SparseArray;
 import java.util.List;
 
 @SuppressLint("Assert")
-public class ManualStepMigration implements MigrationEngine {
+public class ManualStepMigration extends AbstractMigrationEngine {
 
     public static final String TAG = "ManualStepMigration";
 
@@ -46,8 +46,6 @@ public class ManualStepMigration implements MigrationEngine {
 
     static final String kSql = "sql";
 
-    final int version;
-
     final boolean trace;
 
     final SparseArray<Step> steps;
@@ -55,7 +53,7 @@ public class ManualStepMigration implements MigrationEngine {
     boolean tableCreated = false;
 
     public ManualStepMigration(int version, SparseArray<Step> steps, boolean trace) {
-        this.version = version;
+        super(version);
         this.trace = trace;
         this.steps = steps.clone();
     }
@@ -66,11 +64,6 @@ public class ManualStepMigration implements MigrationEngine {
 
     public void addStep(int version, @NonNull Step step) {
         steps.put(version, step);
-    }
-
-    @Override
-    public int getVersion() {
-        return version;
     }
 
     public int getDbVersion(SQLiteDatabase db) {


### PR DESCRIPTION
It's safer to use `BuildConfig.VERSION_CODE` in SchemaDiffMigration than `ApplicationInfo#lastUpdateTime`.