### PR TITLE
Static Type Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,15 @@ class Book {
 
 Orma models are able to have embedded objects with **type adapters**.
 
-Type adapters serializes and deserializes custom classes, for example as a JSON format.
+### Static Type Adapters
 
-If you use type adapters, you can add them to `OrmaDatabase`:
+TBD
+
+### Dynamic Type Adapters
+
+**This is deprecated and will be removed in v2.0.**
+
+If you use type adapters, you can add type serializer instances to `OrmaDatabase`.
 
 ```java
 class FooAdapter extends AbstractTypeAdapter<Foo> {
@@ -473,8 +479,6 @@ OrmaDatabase orma = OrmaDatabase.builder(context)
     .addTypeAdapters(new FooAdapter())
     .build();
 ```
-
-**The interface is experimental and are likely to change in v2.0.**
 
 ### Built-In Type Adapters
 

--- a/README.md
+++ b/README.md
@@ -452,7 +452,26 @@ Orma models are able to have embedded objects with **type adapters**.
 
 ### Static Type Adapters
 
-TBD
+Static type adapters are defined by `@StaticTypeAdapter` with `targetType` and `serializedType` options.
+
+```java
+@StaticTypeAdapter(
+        targetType = Foo.class,
+        serializedType = String.class
+)
+public class IntTuple2Adapter {
+
+    public static String serialize(@NonNull Foo source) {
+        return source.toStrng();
+    }
+
+    @NonNull
+    public static Foo deserialize(long serialized) {
+        return new Foo(serialized);
+    }
+}
+
+```
 
 ### Dynamic Type Adapters
 

--- a/README.md
+++ b/README.md
@@ -452,15 +452,16 @@ Orma models are able to have embedded objects with **type adapters**.
 
 ### Static Type Adapters
 
-Static type adapters are defined by `@StaticTypeAdapter` with `targetType` and `serializedType` options.
+Static type adapters are used to serialize and deserialize a object on inserting a model or selecting a model, respectively.
+
+They are defined by `@StaticTypeAdapter` with `targetType` and `serializedType` options:
 
 ```java
 @StaticTypeAdapter(
         targetType = Foo.class,
         serializedType = String.class
 )
-public class IntTuple2Adapter {
-
+public class FooAdapter {
     public static String serialize(@NonNull Foo source) {
         return source.toStrng();
     }
@@ -472,6 +473,21 @@ public class IntTuple2Adapter {
 }
 
 ```
+
+Target type must be integers, floating point numbers, `boolean`, `String`, or `byte[]`.
+
+Each target type has a corresponding SQLite storage type:
+
+| Java Type | SQLite Type |
+|:---------:|:-----------:|
+| int       | INTEGER     |
+| short     | INTEGER     |
+| long      | INTEGER     |
+| boolean   | INTEGER     |
+| float     | REAL        |
+| double    | REAL        |
+| String    | TEXT        |
+| byte[]    | BLOB        |
 
 ### Dynamic Type Adapters
 
@@ -499,17 +515,21 @@ OrmaDatabase orma = OrmaDatabase.builder(context)
     .build();
 ```
 
-### Built-In Type Adapters
+## Built-In Type Adapters
 
-There are a lot of built-in type adapter provided by default, which include:
+There are built-in type adapters:
 
-* `StringListAdapter` for `List<String>`
-* `StringSetAdapter` for `Set<String>`
-* `DateAdapter` for `Date`
-* `UriAdapter` for `Uri`
 
-See [adapter/](library/src/main/java/com/github/gfx/android/orma/adapter)
-for all the adapters.
+* `java.math.BigDecimal`
+* `java.math.BigInteger`
+* `java.nio.ByteBuffer`
+* `java.util.Currency`
+* `java.util.List<String>`
+* `java.util.Set<String>`
+* `java.util.UUID`
+* `android.net.Uri`
+
+More classes? Patches welcome!
 
 ## Migration
 

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
@@ -13,33 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.gfx.android.orma.example.orma;
 
-import com.github.gfx.android.orma.annotation.Column;
-import com.github.gfx.android.orma.annotation.PrimaryKey;
-import com.github.gfx.android.orma.annotation.Table;
+package com.github.gfx.android.orma.annotation;
 
-import android.support.annotation.Nullable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import java.util.Date;
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+public @interface StaticTypeAdapter {
+    String serializer() default "serialize";
 
-@Table
-public class Todo {
+    String deserializer() default "deserialize";
 
-    @PrimaryKey
-    public long id;
+    Class<?> targetType();
 
-    @Column(indexed = true)
-    public String title;
-
-    @Column
-    @Nullable
-    public String content;
-
-    @Column(indexed = true, defaultExpr = "0")
-    public boolean done;
-
-    @Column(indexed = true)
-    public Date createdTimeMillis;
-
+    Class<?> serializedType();
 }

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
@@ -21,15 +21,31 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * {@link StaticTypeAdapter} defines how a type is stored in a database column.
+ */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
 public @interface StaticTypeAdapter {
 
+    /**
+     * @return The name of a static method used to serialize {@link #targetType()} to {@link #serializedType()}
+     */
     String serializer() default "serialize";
 
+    /**
+     * @return the name of a static method used to deserialize {@link #targetType()} from {@link #serializedType()}
+     */
     String deserializer() default "deserialize";
 
+    /**
+     * @return A target type to serialize.
+     */
     Class<?> targetType();
 
+    /**
+     * @return What {@link #targetType()}} is serialized to. Must be integers, floating point numbers, {@link String} and
+     * {@link byte[]}
+     */
     Class<?> serializedType();
 }

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
 public @interface StaticTypeAdapter {
+
     String serializer() default "serialize";
 
     String deserializer() default "deserialize";

--- a/example/src/main/java/com/github/gfx/android/orma/example/activity/BenchmarkActivity.java
+++ b/example/src/main/java/com/github/gfx/android/orma/example/activity/BenchmarkActivity.java
@@ -44,6 +44,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -224,7 +225,7 @@ public class BenchmarkActivity extends AppCompatActivity {
 
                             todo.title = titlePrefix + i;
                             todo.content = contentPrefix + i;
-                            todo.createdTimeMillis = now;
+                            todo.createdTimeMillis = new Date(now);
 
                             statement.execute(todo);
                         }

--- a/example/src/main/java/com/github/gfx/android/orma/example/activity/ListViewActivity.java
+++ b/example/src/main/java/com/github/gfx/android/orma/example/activity/ListViewActivity.java
@@ -37,6 +37,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Date;
+
 import rx.schedulers.Schedulers;
 
 public class ListViewActivity extends AppCompatActivity {
@@ -75,7 +77,7 @@ public class ListViewActivity extends AppCompatActivity {
                         number++;
                         todo.title = "ListView item #" + number;
                         todo.content = ZonedDateTime.now().toString();
-                        todo.createdTimeMillis = System.currentTimeMillis();
+                        todo.createdTimeMillis = new Date();
                         return todo;
                     }
                 })

--- a/example/src/main/java/com/github/gfx/android/orma/example/activity/MainActivity.java
+++ b/example/src/main/java/com/github/gfx/android/orma/example/activity/MainActivity.java
@@ -49,6 +49,7 @@ import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
 
+import java.util.Date;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity
@@ -152,7 +153,7 @@ public class MainActivity extends AppCompatActivity
         Todo todo = new Todo();
         todo.title = "buy";
         todo.content = "milk banana apple";
-        todo.createdTimeMillis = System.currentTimeMillis();
+        todo.createdTimeMillis = new Date();
         orma.insertIntoTodo(todo);
 
         // read

--- a/example/src/main/java/com/github/gfx/android/orma/example/activity/RecyclerViewActivity.java
+++ b/example/src/main/java/com/github/gfx/android/orma/example/activity/RecyclerViewActivity.java
@@ -38,6 +38,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Date;
+
 import rx.schedulers.Schedulers;
 
 public class RecyclerViewActivity extends AppCompatActivity {
@@ -76,7 +78,7 @@ public class RecyclerViewActivity extends AppCompatActivity {
                         number++;
                         todo.title = "RecyclerView item #" + number;
                         todo.content = ZonedDateTime.now().toString();
-                        todo.createdTimeMillis = System.currentTimeMillis();
+                        todo.createdTimeMillis = new Date();
                         return todo;
                     }
                 })

--- a/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
+++ b/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Built-in serializes.
+ */
+public class BuiltInSerializers {
+
+    @NonNull
+    public static String serializeBigDecimal(@NonNull BigDecimal source) {
+        return source.toString();
+    }
+
+    @NonNull
+    public static BigDecimal deserializeBigDecimal(@NonNull String serialized) {
+        return new BigDecimal(serialized);
+    }
+
+    @NonNull
+    public static String serializeBigInteger(@NonNull BigInteger source) {
+        return source.toString();
+    }
+
+    @NonNull
+    public static BigInteger deserializeBigInteger(@NonNull String serialized) {
+        return new BigInteger(serialized);
+    }
+
+    @NonNull
+    public static String serializeCurrency(@NonNull Currency source) {
+        return source.getCurrencyCode();
+    }
+
+    @NonNull
+    public static Currency deserializeCurrency(@NonNull String serialized) {
+        return Currency.getInstance(serialized);
+    }
+
+
+    public static long serializeDate(@NonNull java.util.Date date) {
+        return date.getTime();
+    }
+
+    @NonNull
+    public static java.util.Date deserializeDate(long timeMillis) {
+        return new java.util.Date(timeMillis);
+    }
+
+    @NonNull
+    public static String serializeSqlDate(@NonNull java.sql.Date source) {
+        return source.toString();
+    }
+
+    @NonNull
+    public static java.sql.Date deserializeSqlDate(@NonNull String serialized) {
+        return java.sql.Date.valueOf(serialized);
+    }
+
+    @NonNull
+    public static String serializeSqlTime(@NonNull java.sql.Time source) {
+        return source.toString();
+    }
+
+    @NonNull
+    public static java.sql.Time deserializeSqlTime(@NonNull String serialized) {
+        return java.sql.Time.valueOf(serialized);
+    }
+
+    @NonNull
+    public static String serializeSqlTimestamp(@NonNull java.sql.Timestamp source) {
+        return source.toString();
+    }
+
+    @NonNull
+    public static java.sql.Timestamp deserializeSqlTimestamp(@NonNull String serialized) {
+        return java.sql.Timestamp.valueOf(serialized);
+    }
+
+    @NonNull
+    public static String serializeStringList(@NonNull List<String> source) {
+        JSONArray array = new JSONArray();
+        for (String s : source) {
+            array.put(s);
+        }
+        return array.toString();
+    }
+
+    @NonNull
+    public static List<String> deserializeStringList(@NonNull String serialized) {
+        JSONArray jsonArray;
+        try {
+            jsonArray = new JSONArray(serialized);
+            List<String> list = new ArrayList<>(jsonArray.length());
+
+            for (int i = 0; i < jsonArray.length(); i++) {
+                list.add(jsonArray.getString(i));
+            }
+            return list;
+        } catch (JSONException e) {
+            return new ArrayList<>();
+        }
+    }
+
+    @NonNull
+    public static String serializeStringSet(@NonNull Set<String> source) {
+        JSONArray array = new JSONArray();
+        for (String s : source) {
+            array.put(s);
+        }
+        return array.toString();
+    }
+
+    @NonNull
+    public static Set<String> deserializeStringSet(@NonNull String serialized) {
+        JSONArray jsonArray;
+        try {
+            jsonArray = new JSONArray(serialized);
+            Set<String> set = new HashSet<>(jsonArray.length());
+
+            for (int i = 0; i < jsonArray.length(); i++) {
+                set.add(jsonArray.getString(i));
+            }
+            return set;
+        } catch (JSONException e) {
+            return new HashSet<>();
+        }
+    }
+
+    @NonNull
+    public static String serializeUri(@NonNull Uri source) {
+        return source.toString();
+    }
+
+    @NonNull
+    public static Uri deserializeUri(@NonNull String serialized) {
+        return Uri.parse(serialized);
+    }
+
+    @NonNull
+    public static String serializeUUID(@NonNull UUID source) {
+        return source.toString();
+    }
+
+    @NonNull
+    public static UUID deserializeUUID(@NonNull String serialized) {
+        return UUID.fromString(serialized);
+    }
+
+}

--- a/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
+++ b/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Currency;
 import java.util.HashSet;
@@ -54,6 +55,16 @@ public class BuiltInSerializers {
     @NonNull
     public static BigInteger deserializeBigInteger(@NonNull String serialized) {
         return new BigInteger(serialized);
+    }
+
+    @NonNull
+    public static byte[] serializeByteBuffer(@NonNull ByteBuffer source) {
+        return source.array();
+    }
+
+    @NonNull
+    public static ByteBuffer deserializeByteBuffer(@NonNull byte[] serialized) {
+        return ByteBuffer.wrap(serialized);
     }
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/ColumnDef.java
+++ b/library/src/main/java/com/github/gfx/android/orma/ColumnDef.java
@@ -37,7 +37,8 @@ public abstract class ColumnDef<Model, T> {
 
     public final String name;
 
-    public final Type type;
+    @Deprecated
+    public final Type type; // TODO: will be removed in v2.0
 
     public final String storageType;
 

--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConfiguration.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConfiguration.java
@@ -39,6 +39,7 @@ public abstract class OrmaConfiguration<T extends OrmaConfiguration<?>> {
     @Nullable
     String name;
 
+    @SuppressWarnings("deprecated")
     TypeAdapterRegistry typeAdapterRegistry;
 
     MigrationEngine migrationEngine;
@@ -96,6 +97,8 @@ public abstract class OrmaConfiguration<T extends OrmaConfiguration<?>> {
      * @param typeAdapters Custom type adapters to add
      * @return the receiver itself
      */
+    @Deprecated
+    @SuppressWarnings("deprecated")
     public T typeAdapters(@NonNull TypeAdapter<?>... typeAdapters) {
         if (typeAdapterRegistry == null) {
             typeAdapterRegistry = new TypeAdapterRegistry();
@@ -188,6 +191,7 @@ public abstract class OrmaConfiguration<T extends OrmaConfiguration<?>> {
         return (T) this;
     }
 
+    @SuppressWarnings("deprecated")
     protected T fillDefaults() {
 
         if (migrationEngine == null) {

--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
@@ -65,6 +65,8 @@ public class OrmaConnection extends SQLiteOpenHelper {
 
     final boolean trace;
 
+    @SuppressWarnings("deprecated")
+    @Deprecated
     final TypeAdapterRegistry typeAdapterRegistry;
 
     final AccessThreadConstraint readOnMainThread;
@@ -133,12 +135,20 @@ public class OrmaConnection extends SQLiteOpenHelper {
         return super.getReadableDatabase();
     }
 
+    @Deprecated
+    @SuppressWarnings("deprecated")
     @NonNull
     public <SourceType> TypeAdapter<SourceType> getTypeAdapter(Type sourceType) {
         return typeAdapterRegistry.get(sourceType);
     }
 
-    @Deprecated // because type adapter registry will become global, static object
+    /**
+     * Use {@link com.github.gfx.android.orma.annotation.StaticTypeAdapter} instead.
+     *
+     * @return the instance of TypeAdapterRegistry
+     */
+    @Deprecated
+    @SuppressWarnings("deprecated")
     public TypeAdapterRegistry getTypeAdapterRegistry() {
         return typeAdapterRegistry;
     }

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/AbstractTypeAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/AbstractTypeAdapter.java
@@ -23,6 +23,12 @@ import android.support.annotation.Nullable;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+/**
+ * Deprecated; use {@link com.github.gfx.android.orma.annotation.StaticTypeAdapter} instead.
+ *
+ * @param <SourceType> the target type
+ */
+@Deprecated
 public abstract class AbstractTypeAdapter<SourceType> implements TypeAdapter<SourceType> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/BigDecimalAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/BigDecimalAdapter.java
@@ -19,6 +19,7 @@ import android.support.annotation.NonNull;
 
 import java.math.BigDecimal;
 
+@Deprecated
 public class BigDecimalAdapter extends AbstractTypeAdapter<BigDecimal> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/BigIntegerAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/BigIntegerAdapter.java
@@ -19,6 +19,7 @@ import android.support.annotation.NonNull;
 
 import java.math.BigInteger;
 
+@Deprecated
 public class BigIntegerAdapter extends AbstractTypeAdapter<BigInteger> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/DateAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/DateAdapter.java
@@ -23,6 +23,7 @@ import java.util.Date;
  * Handles {@link Date} as an integer, or <strong>milliseconds</strong>.
  * Use {@link java.sql.Timestamp} if you want to use SQLite date/time functions.
  */
+@Deprecated
 public class DateAdapter extends AbstractTypeAdapter<Date> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/SqlDateAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/SqlDateAdapter.java
@@ -22,6 +22,7 @@ import java.sql.Date;
 /**
  * Handles {@link Date} as a string representation like {@code "2015-12-23"}.
  */
+@Deprecated
 public class SqlDateAdapter extends AbstractTypeAdapter<Date> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/SqlTimeAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/SqlTimeAdapter.java
@@ -22,6 +22,7 @@ import java.sql.Time;
 /**
  * Handles {@link Time} as a string representation like {@code "12:30:45"}.
  */
+@Deprecated
 public class SqlTimeAdapter extends AbstractTypeAdapter<Time> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/SqlTimestampAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/SqlTimestampAdapter.java
@@ -22,6 +22,7 @@ import java.sql.Timestamp;
 /**
  * Handles {@link Timestamp} as a string representation like {@code "2015-12-23 18:23:45"}.
  */
+@Deprecated
 public class SqlTimestampAdapter extends AbstractTypeAdapter<Timestamp> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/StringListAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/StringListAdapter.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class StringListAdapter extends AbstractTypeAdapter<List<String>> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/StringSetAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/StringSetAdapter.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import java.util.HashSet;
 import java.util.Set;
 
+@Deprecated
 public class StringSetAdapter extends AbstractTypeAdapter<Set<String>> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/TypeAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/TypeAdapter.java
@@ -20,6 +20,12 @@ import android.support.annotation.Nullable;
 
 import java.lang.reflect.Type;
 
+/**
+ * Deprecated; use {@link com.github.gfx.android.orma.annotation.StaticTypeAdapter} instead.
+ *
+ * @param <SourceType> the target type
+ */
+@Deprecated
 public interface TypeAdapter<SourceType> {
 
     Type getSourceType();

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/TypeAdapterRegistry.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/TypeAdapterRegistry.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+@Deprecated
 public class TypeAdapterRegistry {
 
     final Map<Type, TypeAdapter<?>> adapters = new HashMap<>();

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/UUIDAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/UUIDAdapter.java
@@ -19,6 +19,7 @@ import android.support.annotation.NonNull;
 
 import java.util.UUID;
 
+@Deprecated
 public class UUIDAdapter extends AbstractTypeAdapter<UUID> {
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/adapter/UriAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/adapter/UriAdapter.java
@@ -18,6 +18,7 @@ package com.github.gfx.android.orma.adapter;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+@Deprecated
 public class UriAdapter extends AbstractTypeAdapter<Uri> {
 
     @NonNull

--- a/library/src/test/java/com/github/gfx/android/orma/test/DeprecatedDynamicTypeAdapterTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/DeprecatedDynamicTypeAdapterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test;
+
+import com.github.gfx.android.orma.ModelFactory;
+import com.github.gfx.android.orma.adapter.AbstractTypeAdapter;
+import com.github.gfx.android.orma.test.model.ModelWithDeprecatedTypeAdapter;
+import com.github.gfx.android.orma.test.model.OrmaDatabase;
+import com.github.gfx.android.orma.test.toolbox.IntTuple2x;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Will be removed in v2.0
+ */
+@RunWith(AndroidJUnit4.class)
+public class DeprecatedDynamicTypeAdapterTest {
+
+    @SuppressWarnings("deprecated")
+    @Test
+    public void testDynamicTypeAdapter() throws Exception {
+        OrmaDatabase orma = OrmaDatabase.builder(InstrumentationRegistry.getTargetContext())
+                .typeAdapters(new AbstractTypeAdapter<IntTuple2x>() {
+                    @NonNull
+                    @Override
+                    public String serialize(@NonNull IntTuple2x tuple) {
+                        return String.valueOf(((long) tuple.first << 32) | (long) tuple.second);
+                    }
+
+                    @NonNull
+                    @Override
+                    public IntTuple2x deserialize(@NonNull String serialized) {
+                        long value = Long.parseLong(serialized);
+                        return new IntTuple2x((int) (value >> 32), (int) value);
+                    }
+                })
+                .build();
+
+       ModelWithDeprecatedTypeAdapter model = orma.createModelWithDeprecatedTypeAdapter(
+                new ModelFactory<ModelWithDeprecatedTypeAdapter>() {
+                    @Override
+                    public ModelWithDeprecatedTypeAdapter call() {
+                        ModelWithDeprecatedTypeAdapter model = new ModelWithDeprecatedTypeAdapter();
+                        model.intTuple2 = new IntTuple2x(-13, 17);
+                        return model;
+                    }
+                });
+
+        assertThat(model.intTuple2, is(new IntTuple2x(-13, 17)));
+    }
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
@@ -38,6 +38,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Currency;
 import java.util.Date;
@@ -112,7 +113,7 @@ public class ModelSpecTest {
     }
 
     @Test
-    public void testObjectMapping() throws Exception {
+    public void testModelWithTypeAdapters() throws Exception {
         final long now = System.currentTimeMillis();
         final UUID uuid = UUID.randomUUID();
         final BigDecimal bd = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
@@ -138,6 +139,7 @@ public class ModelSpecTest {
                 model.bigInteger = bi;
                 model.currency = Currency.getInstance("JPY");
                 model.intTuple2 = new IntTuple2(-13, 17);
+                model.byteBuffer = ByteBuffer.wrap(new byte[]{0, 1, 2, 3});
                 return model;
             }
         });
@@ -154,7 +156,12 @@ public class ModelSpecTest {
         assertThat(model.bigInteger, is(bi));
         assertThat(model.currency, is(Currency.getInstance("JPY")));
         assertThat(model.intTuple2, is(new IntTuple2(-13, 17)));
-        assertThat(model.nullableIntTuple2, is(nullValue()));
+        assertThat(model.byteBuffer, is(ByteBuffer.wrap(new byte[]{0, 1, 2, 3})));
+
+        // nullable
+        assertThat(model.nullableUri, is(nullValue())); // TEXT
+        assertThat(model.nullableIntTuple2, is(nullValue())); // INTEGER
+        assertThat(model.nullableByteBuffer, is(nullValue())); // BLOB
     }
 
     @Test

--- a/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
@@ -358,5 +358,4 @@ public class ModelSpecTest {
         assertThat(db.selectFromModelWithConflictResolutions().count(), is(1));
         assertThat(db.selectFromModelWithConflictResolutions().value().primaryKeyOrIgnore, is(11L));
     }
-
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
@@ -25,6 +25,7 @@ import com.github.gfx.android.orma.test.model.ModelWithDefaults;
 import com.github.gfx.android.orma.test.model.ModelWithPrimitives;
 import com.github.gfx.android.orma.test.model.ModelWithTypeAdapters;
 import com.github.gfx.android.orma.test.model.OrmaDatabase;
+import com.github.gfx.android.orma.test.toolbox.IntTuple2;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -136,6 +137,7 @@ public class ModelSpecTest {
                 model.bigDecimal = bd;
                 model.bigInteger = bi;
                 model.currency = Currency.getInstance("JPY");
+                model.intTuple2 = new IntTuple2(-13, 17);
                 return model;
             }
         });
@@ -151,6 +153,8 @@ public class ModelSpecTest {
         assertThat(model.bigDecimal, is(bd));
         assertThat(model.bigInteger, is(bi));
         assertThat(model.currency, is(Currency.getInstance("JPY")));
+        assertThat(model.intTuple2, is(new IntTuple2(-13, 17)));
+        assertThat(model.nullableIntTuple2, is(nullValue()));
     }
 
     @Test

--- a/library/src/test/java/com/github/gfx/android/orma/test/OrmaDatabaseTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/OrmaDatabaseTest.java
@@ -17,8 +17,6 @@ package com.github.gfx.android.orma.test;
 
 import com.github.gfx.android.orma.AccessThreadConstraint;
 import com.github.gfx.android.orma.ModelFactory;
-import com.github.gfx.android.orma.adapter.DateAdapter;
-import com.github.gfx.android.orma.adapter.UriAdapter;
 import com.github.gfx.android.orma.test.model.Author;
 import com.github.gfx.android.orma.test.model.OrmaDatabase;
 
@@ -76,7 +74,6 @@ public class OrmaDatabaseTest {
     public void testCreateInstance() throws Exception {
         OrmaDatabase db = OrmaDatabase.builder(getContext())
                 .name(NAME)
-                .typeAdapters(new UriAdapter(), new DateAdapter())
                 .readOnMainThread(AccessThreadConstraint.NONE)
                 .writeOnMainThread(AccessThreadConstraint.NONE)
                 .tryParsingSql(false)

--- a/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
@@ -19,6 +19,7 @@ import com.github.gfx.android.orma.ColumnDef;
 import com.github.gfx.android.orma.test.model.Author_Schema;
 import com.github.gfx.android.orma.test.model.Book_Schema;
 import com.github.gfx.android.orma.test.model.ModelWithStorageTypes_Schema;
+import com.github.gfx.android.orma.test.model.ModelWithTypeAdapters_Schema;
 import com.github.gfx.android.orma.test.model.OrmaDatabase;
 import com.github.gfx.android.orma.test.model.PublisherSchema;
 
@@ -97,4 +98,14 @@ public class SchemaTest {
                 "CREATE TABLE \"ModelWithStorageTypes\" (\"date\" INTEGER NOT NULL, \"timestamp\" DATETIME NOT NULL)"
         ));
     }
+
+    @Test
+    public void testStaticTypeAdapterStorageTypes() throws Exception {
+        assertThat(ModelWithTypeAdapters_Schema.date.storageType, is("INTEGER"));
+        assertThat(ModelWithTypeAdapters_Schema.sqlDate.storageType, is("TEXT"));
+        assertThat(ModelWithTypeAdapters_Schema.sqlTime.storageType, is("TEXT"));
+        assertThat(ModelWithTypeAdapters_Schema.sqlTimestamp.storageType, is("TEXT"));
+        assertThat(ModelWithTypeAdapters_Schema.intTuple2.storageType, is("INTEGER"));
+    }
+
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/TypeAdaptersTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/TypeAdaptersTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
+@SuppressWarnings("deprecated")
 public class TypeAdaptersTest {
 
     static final Type stringListType = new TypeHolder<List<String>>() {

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithBoxTypes.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithBoxTypes.java
@@ -18,6 +18,13 @@ package com.github.gfx.android.orma.test.model;
 import com.github.gfx.android.orma.annotation.Column;
 import com.github.gfx.android.orma.annotation.Table;
 
+import android.support.annotation.Nullable;
+
+/**
+ * @see ModelWithBoxTypes_Schema
+ *
+ * @see ModelWithPrimitives
+ */
 @Table
 public class ModelWithBoxTypes {
 
@@ -41,5 +48,33 @@ public class ModelWithBoxTypes {
 
     @Column
     public Double doubleValue;
+
+    @Column
+    @Nullable
+    public Boolean nullableBooleanValue;
+
+    @Column
+    @Nullable
+    public Byte nullableByteValue;
+
+    @Column
+    @Nullable
+    public Short nullableShortValue;
+
+    @Column
+    @Nullable
+    public Integer nullableIntValue;
+
+    @Column
+    @Nullable
+    public Long nullableLongValue;
+
+    @Column
+    @Nullable
+    public Float nullableFloatValue;
+
+    @Column
+    @Nullable
+    public Double nullableDoubleValue;
 
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithDeprecatedTypeAdapter.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithDeprecatedTypeAdapter.java
@@ -13,24 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.gfx.android.orma.adapter;
 
-import android.support.annotation.NonNull;
+package com.github.gfx.android.orma.test.model;
 
-import java.util.Currency;
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+import com.github.gfx.android.orma.test.toolbox.IntTuple2x;
 
-@Deprecated
-public class CurrencyAdapter extends AbstractTypeAdapter<Currency> {
+@Table
+public class ModelWithDeprecatedTypeAdapter {
 
-    @NonNull
-    @Override
-    public String serialize(@NonNull Currency source) {
-        return source.getCurrencyCode();
-    }
-
-    @NonNull
-    @Override
-    public Currency deserialize(@NonNull String serialized) {
-        return Currency.getInstance(serialized);
-    }
+    @Column
+    public IntTuple2x intTuple2;
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithPrimitives.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithPrimitives.java
@@ -18,6 +18,11 @@ package com.github.gfx.android.orma.test.model;
 import com.github.gfx.android.orma.annotation.Column;
 import com.github.gfx.android.orma.annotation.Table;
 
+/**
+ * @see ModelWithPrimitives_Schema
+ *
+ * @see ModelWithBoxTypes
+ */
 @Table
 public class ModelWithPrimitives {
 
@@ -41,5 +46,4 @@ public class ModelWithPrimitives {
 
     @Column
     public double doubleValue;
-
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
@@ -18,6 +18,7 @@ package com.github.gfx.android.orma.test.model;
 import com.github.gfx.android.orma.annotation.Column;
 import com.github.gfx.android.orma.annotation.PrimaryKey;
 import com.github.gfx.android.orma.annotation.Table;
+import com.github.gfx.android.orma.test.toolbox.IntTuple2;
 
 import android.net.Uri;
 import android.support.annotation.Nullable;
@@ -69,6 +70,9 @@ public class ModelWithTypeAdapters {
     @Column(indexed = true)
     public Currency currency;
 
+    @Column(indexed = true)
+    public IntTuple2 intTuple2;
+
     @Nullable
     @Column(indexed = true)
     public List<String> nullableList;
@@ -84,4 +88,8 @@ public class ModelWithTypeAdapters {
     @Nullable
     @Column(indexed = true)
     public Date nullableDate;
+
+    @Column(indexed = true)
+    @Nullable
+    public IntTuple2 nullableIntTuple2;
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
@@ -25,6 +25,7 @@ import android.support.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.Currency;
 import java.util.Date;
 import java.util.List;
@@ -71,6 +72,9 @@ public class ModelWithTypeAdapters {
     public Currency currency;
 
     @Column(indexed = true)
+    public ByteBuffer byteBuffer;
+
+    @Column(indexed = true)
     public IntTuple2 intTuple2;
 
     @Nullable
@@ -92,4 +96,8 @@ public class ModelWithTypeAdapters {
     @Column(indexed = true)
     @Nullable
     public IntTuple2 nullableIntTuple2;
+
+    @Column(indexed = true)
+    @Nullable
+    public ByteBuffer nullableByteBuffer;
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/toolbox/IntTuple2.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/toolbox/IntTuple2.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.toolbox;
+
+public class IntTuple2 {
+
+    public final int first;
+
+    public final int second;
+
+    public IntTuple2(int first, int second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof IntTuple2)) {
+            return false;
+        }
+
+        IntTuple2 intTuple2 = (IntTuple2) o;
+
+        if (first != intTuple2.first) {
+            return false;
+        }
+        return second == intTuple2.second;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = first;
+        result = 31 * result + second;
+        return result;
+    }
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/toolbox/IntTuple2x.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/toolbox/IntTuple2x.java
@@ -17,17 +17,15 @@
 package com.github.gfx.android.orma.test.toolbox;
 
 /**
- * A demo class to show how {@link com.github.gfx.android.orma.annotation.StaticTypeAdapter} works.
- *
- * @see com.github.gfx.android.orma.test.type_adapter.IntTuple2Adapter
+ * A demo class to show how the deprecated {@link com.github.gfx.android.orma.adapter.TypeAdapter} works.
  */
-public class IntTuple2 {
+public class IntTuple2x {
 
     public final int first;
 
     public final int second;
 
-    public IntTuple2(int first, int second) {
+    public IntTuple2x(int first, int second) {
         this.first = first;
         this.second = second;
     }
@@ -37,11 +35,11 @@ public class IntTuple2 {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof IntTuple2)) {
+        if (!(o instanceof IntTuple2x)) {
             return false;
         }
 
-        IntTuple2 intTuple2 = (IntTuple2) o;
+        IntTuple2x intTuple2 = (IntTuple2x) o;
 
         if (first != intTuple2.first) {
             return false;

--- a/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/IntTuple2Adapter.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/IntTuple2Adapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.type_adapter;
+
+import com.github.gfx.android.orma.annotation.StaticTypeAdapter;
+import com.github.gfx.android.orma.test.toolbox.IntTuple2;
+
+import android.support.annotation.NonNull;
+
+@StaticTypeAdapter(
+        targetType = IntTuple2.class,
+        serializedType = long.class
+)
+public class IntTuple2Adapter {
+
+    public static long serialize(@NonNull IntTuple2 tuple) {
+        return ((long) tuple.first << 32) | (long) tuple.second;
+    }
+
+    @NonNull
+    public static IntTuple2 deserialize(long serialized) {
+        return new IntTuple2((int) (serialized >> 32), (int) serialized);
+    }
+}

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/ColumnDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/ColumnDefinition.java
@@ -300,7 +300,8 @@ public class ColumnDefinition {
                     .add("$T.$L($L)", typeAdapter.typeAdapterImpl, typeAdapter.getSerializerName(), valueExpr)
                     .build();
         } else {
-            // dynamic type adapters
+            // TODO: remove this branch in v2.0
+            // dynamic type adapters (DEPRECATED)
             CodeBlock.Builder expr = CodeBlock.builder();
             if (needsTypeAdapter()) {
                 expr.add("$L.$L($L)",

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/ConditionQueryHelpers.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/ConditionQueryHelpers.java
@@ -75,7 +75,7 @@ public class ConditionQueryHelpers {
                         associatedSchema.getElement());
             }
             serializedFieldExpr = CodeBlock.builder()
-                    .add("$L.$L /* primary key */", paramSpec.name, primaryKey.buildGetColumnExpr())
+                    .add("$L /* primary key */", primaryKey.buildGetColumnExpr(paramSpec.name))
                     .build();
         } else {
             serializedFieldExpr = column.buildSerializeExpr("conn", paramSpec.name);

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/Mirrors.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/Mirrors.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.processor;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Utilities for AnnotationMirror
+ */
+public class Mirrors {
+
+    @Nullable
+    public static AnnotationMirror findAnnotationMirror(Element element, Class<? extends Annotation> annotationClass) {
+        for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+            DeclaredType declaredType = annotationMirror.getAnnotationType();
+            TypeElement typeElement = (TypeElement) declaredType.asElement();
+            if (typeElement.getQualifiedName().contentEquals(annotationClass.getName())) {
+                return annotationMirror;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    public static AnnotationValue findAnnotationValue(AnnotationMirror annotationMirror, String name) {
+        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry
+                : annotationMirror.getElementValues().entrySet()) {
+            if (entry.getKey().getSimpleName().contentEquals(name)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    @NonNull
+    public static TypeMirror findAnnotationValueAsTypeMirror(AnnotationMirror annotationMirror, String name) {
+        AnnotationValue value = findAnnotationValue(annotationMirror, name);
+        if (value != null) {
+            return (TypeMirror) value.getValue();
+        }
+        throw new RuntimeException("No annotation value for " + annotationMirror.getAnnotationType() + "#" + name + "()");
+    }
+
+    @Nullable
+    public static String findAnnotationValueAsTypeStringOrNull(AnnotationMirror annotationMirror, String name) {
+        AnnotationValue value = findAnnotationValue(annotationMirror, name);
+        if (value != null) {
+            return (String) value.getValue();
+        }
+        return null;
+    }
+}

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/OrmaProcessor.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/OrmaProcessor.java
@@ -15,6 +15,7 @@
  */
 package com.github.gfx.android.orma.processor;
 
+import com.github.gfx.android.orma.annotation.StaticTypeAdapter;
 import com.github.gfx.android.orma.annotation.Table;
 import com.github.gfx.android.orma.annotation.VirtualTable;
 import com.squareup.javapoet.JavaFile;
@@ -48,6 +49,9 @@ public class OrmaProcessor extends AbstractProcessor {
         ProcessingContext context = new ProcessingContext(processingEnv);
 
         try {
+            buildTypeAdapters(context, roundEnv)
+                    .forEach(context::addTypeAdapterDefinition);
+
             buildTableSchemas(context, roundEnv)
                     .forEach(schema -> context.schemaMap.put(schema.getModelClassName(), schema));
 
@@ -82,6 +86,13 @@ public class OrmaProcessor extends AbstractProcessor {
         context.printErrors();
 
         return false;
+    }
+
+    public Stream<TypeAdapterDefinition> buildTypeAdapters(ProcessingContext context, RoundEnvironment roundEnv) {
+        return roundEnv
+                .getElementsAnnotatedWith(StaticTypeAdapter.class)
+                .stream()
+                .map(TypeAdapterDefinition::new);
     }
 
     public Stream<SchemaDefinition> buildTableSchemas(ProcessingContext context, RoundEnvironment roundEnv) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
@@ -21,6 +21,7 @@ import com.squareup.javapoet.TypeName;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,11 +40,17 @@ public class ProcessingContext {
 
     public final Map<TypeName, SchemaDefinition> schemaMap;
 
+    public final Map<TypeName, TypeAdapterDefinition> typeAdapterMap;
+
     public ClassName OrmaDatabase;
 
     public ProcessingContext(ProcessingEnvironment processingEnv) {
         this.processingEnv = processingEnv;
         this.schemaMap = new LinkedHashMap<>(); // the order matters
+        this.typeAdapterMap = new HashMap<>();
+        for (TypeAdapterDefinition typeAdapterDefinition : TypeAdapterDefinition.BUILTINS) {
+            addTypeAdapterDefinition(typeAdapterDefinition);
+        }
     }
 
     public void addError(String message, Element element) {
@@ -59,6 +66,10 @@ public class ProcessingContext {
 
         errors.forEach(error -> messager.printMessage(
                 Diagnostic.Kind.ERROR, error.getMessage(), error.element));
+    }
+
+    public void addTypeAdapterDefinition(TypeAdapterDefinition typeAdapterDefinition) {
+        typeAdapterMap.put(typeAdapterDefinition.targetType, typeAdapterDefinition);
     }
 
     public SchemaDefinition getSchemaDef(TypeName modelClassName) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/SchemaWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/SchemaWriter.java
@@ -479,7 +479,10 @@ public class SchemaWriter extends BaseWriter {
             } else if (r != null && r.associationType.equals(Types.SingleAssociation)) {
                 builder.addStatement("statement.bindLong($L, $L.getId())", n, c.buildGetColumnExpr("model"));
             } else {
-                throw new ProcessingException("No storage method found for " + serializedType, c.element);
+                builder.addStatement("statement.bindString($L, $L)", n, rhsExpr);
+
+                // TODO: throw the following errors in v2.0
+                // throw new ProcessingException("No storage method found for " + serializedType, c.element);
             }
 
             if (c.isNullableInJava()) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/SchemaWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/SchemaWriter.java
@@ -152,7 +152,7 @@ public class SchemaWriter extends BaseWriter {
                         .addAnnotation(Specs.nonNullAnnotationSpec())
                         .build());
         if (c.element != null) {
-            getBuilder.addStatement("return model.$L", c.buildGetColumnExpr());
+            getBuilder.addStatement("return $L", c.buildGetColumnExpr("model"));
         } else {
             getBuilder.addStatement("throw new $T($S)", Types.NoValueException, "Missing @PrimaryKey definition");
         }
@@ -424,27 +424,6 @@ public class SchemaWriter extends BaseWriter {
         return methodSpecs;
     }
 
-    private CodeBlock buildGetField() {
-        CodeBlock.Builder builder = CodeBlock.builder();
-
-        builder.beginControlFlow("switch (column.name)");
-
-        for (ColumnDefinition column : schema.getColumns()) {
-            if (column.type.isPrimitive()) {
-                builder.addStatement("case $S: return ($T)($T)model.$L",
-                        column.columnName, Types.T, column.getBoxType(), column.buildGetColumnExpr());
-            } else {
-                builder.addStatement("case $S: return ($T)model.$L",
-                        column.columnName, Types.T, column.buildGetColumnExpr());
-            }
-        }
-
-        builder.addStatement("default: throw new $T()", AssertionError.class);
-        builder.endControlFlow();
-
-        return builder.build();
-    }
-
     private CodeBlock buildConvertToArgs() {
         CodeBlock.Builder builder = CodeBlock.builder();
 
@@ -453,30 +432,16 @@ public class SchemaWriter extends BaseWriter {
 
         for (int i = 0; i < columns.size(); i++) {
             ColumnDefinition c = columns.get(i);
-            TypeName type = c.getUnboxType();
             AssociationDefinition r = c.getAssociation();
 
-            if (type.equals(TypeName.BOOLEAN)) {
-                if (c.nullable) {
-                    builder.beginControlFlow("if (model.$L != null)", c.buildGetColumnExpr());
-                }
-                builder.addStatement("args[$L] = model.$L ? 1 : 0", i, c.buildGetColumnExpr());
-                if (c.nullable) {
-                    builder.endControlFlow();
-                }
-            } else if (Types.looksLikeIntegerType(type)) {
-                builder.addStatement("args[$L] = model.$L", i, c.buildGetColumnExpr());
-            } else if (Types.looksLikeFloatType(type)) {
-                builder.addStatement("args[$L] = model.$L", i, c.buildGetColumnExpr());
-            } else if (type.equals(Types.ByteArray)) {
-                builder.addStatement("args[$L] = model.$L", i, c.buildGetColumnExpr());
-            } else if (type.equals(Types.String)) {
-                builder.addStatement("args[$L] = model.$L", i, c.buildGetColumnExpr());
-            } else if (r != null && r.associationType.equals(Types.SingleAssociation)) {
-                builder.addStatement("args[$L] = model.$L.getId()", i, c.buildGetColumnExpr());
+            CodeBlock rhsExpr = c.buildSerializedColumnExpr("conn", "model");
+
+            if (r != null && r.associationType.equals(Types.SingleAssociation)) {
+                builder.addStatement("args[$L] = $L.getId()", i, c.buildGetColumnExpr("model"));
+            } else if (c.getSerializedType().equals(TypeName.BOOLEAN)) {
+                builder.addStatement("args[$L] = $L ? 1 : 0", i, rhsExpr);
             } else {
-                builder.addStatement("args[$L] = $L",
-                        i, c.buildSerializeExpr("conn", "model." + c.buildGetColumnExpr()));
+                builder.addStatement("args[$L] = $L", i, rhsExpr);
             }
         }
 
@@ -492,32 +457,32 @@ public class SchemaWriter extends BaseWriter {
         for (int i = 0; i < columns.size(); i++) {
             int n = i + 1; // bind index starts 1
             ColumnDefinition c = columns.get(i);
-            TypeName type = c.getUnboxType();
+            TypeName serializedType = c.getSerializedType();
             AssociationDefinition r = c.getAssociation();
-            boolean nullable = !c.getType().isPrimitive() && c.nullable;
 
-            if (nullable) {
-                builder.beginControlFlow("if (model.$L != null)", c.buildGetColumnExpr());
+            if (c.isNullableInJava()) {
+                builder.beginControlFlow("if ($L != null)", c.buildGetColumnExpr("model"));
             }
 
-            if (type.equals(TypeName.BOOLEAN)) {
-                builder.addStatement("statement.bindLong($L, model.$L ? 1 : 0)", n, c.buildGetColumnExpr());
-            } else if (Types.looksLikeIntegerType(type)) {
-                builder.addStatement("statement.bindLong($L, model.$L)", n, c.buildGetColumnExpr());
-            } else if (Types.looksLikeFloatType(type)) {
-                builder.addStatement("statement.bindDouble($L, model.$L)", n, c.buildGetColumnExpr());
-            } else if (type.equals(Types.ByteArray)) {
-                builder.addStatement("statement.bindBlob($L, model.$L)", n, c.buildGetColumnExpr());
-            } else if (type.equals(Types.String)) {
-                builder.addStatement("statement.bindString($L, model.$L)", n, c.buildGetColumnExpr());
+            CodeBlock rhsExpr = c.buildSerializedColumnExpr("conn", "model");
+
+            if (serializedType.equals(TypeName.BOOLEAN)) {
+                builder.addStatement("statement.bindLong($L, $L ? 1 : 0)", n, rhsExpr);
+            } else if (Types.looksLikeIntegerType(serializedType)) {
+                builder.addStatement("statement.bindLong($L, $L)", n, rhsExpr);
+            } else if (Types.looksLikeFloatType(serializedType)) {
+                builder.addStatement("statement.bindDouble($L, $L)", n, rhsExpr);
+            } else if (serializedType.equals(Types.ByteArray)) {
+                builder.addStatement("statement.bindBlob($L, $L)", n, rhsExpr);
+            } else if (serializedType.equals(Types.String)) {
+                builder.addStatement("statement.bindString($L, $L)", n, rhsExpr);
             } else if (r != null && r.associationType.equals(Types.SingleAssociation)) {
-                builder.addStatement("statement.bindLong($L, model.$L.getId())", n, c.buildGetColumnExpr());
+                builder.addStatement("statement.bindLong($L, $L.getId())", n, c.buildGetColumnExpr("model"));
             } else {
-                builder.addStatement("statement.bindString($L, $L)",
-                        n, c.buildSerializeExpr("conn", "model." + c.buildGetColumnExpr()));
+                throw new ProcessingException("No storage method found for " + serializedType, c.element);
             }
 
-            if (nullable) {
+            if (c.isNullableInJava()) {
                 builder.endControlFlow();
                 builder.beginControlFlow("else");
                 builder.addStatement("statement.bindNull($L)", n);
@@ -547,18 +512,14 @@ public class SchemaWriter extends BaseWriter {
                                 r.associationType, context.getSchemaInstanceExpr(r.modelType), i);
                 builder.addStatement("$L$L", lhsBaseGen.apply(c), c.buildSetColumnExpr(getRhsExpr.build()));
             } else {
-                CodeBlock.Builder getRhsExpr = CodeBlock.builder();
-                if (Types.needsTypeAdapter(type)) {
-                    getRhsExpr.add("$L.$L($L)",
-                            c.buildGetTypeAdapter("conn"),
-                            c.nullable ? "deserializeNullable" : "deserialize",
-                            cursorGetter(c, i));
-                } else {
-                    getRhsExpr.add("$L",
-                            cursorGetter(c, i));
+                if (c.isNullableInSQL()) {
+                    builder.beginControlFlow("if (!cursor.isNull($L))", i);
                 }
-
-                builder.addStatement("$L$L", lhsBaseGen.apply(c), c.buildSetColumnExpr(getRhsExpr.build()));
+                CodeBlock getRhsExpr = c.buildDeserializeExpr("conn", cursorGetter(c, i));
+                builder.addStatement("$L$L", lhsBaseGen.apply(c), c.buildSetColumnExpr(getRhsExpr));
+                if (c.isNullableInSQL()) {
+                    builder.endControlFlow();
+                }
             }
         }
         return builder.build();
@@ -597,7 +558,7 @@ public class SchemaWriter extends BaseWriter {
     }
 
     private String cursorGetter(ColumnDefinition column, int position) {
-        TypeName type = column.getUnboxType();
+        TypeName type = column.getSerializedType();
         if (type.equals(TypeName.BOOLEAN)) {
             return "cursor.getLong(" + position + ") != 0";
         } else if (type.equals(TypeName.BYTE)) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/SqlTypes.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/SqlTypes.java
@@ -55,7 +55,7 @@ public class SqlTypes {
     }
 
     public static String getSqliteType(TypeName type) {
-        String t = javaToSqlite.get(type);
+        String t = javaToSqlite.get(Types.asUnboxType(type));
         return t != null ? t : "BLOB";
     }
 }

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/TypeAdapterDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/TypeAdapterDefinition.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.processor;
+
+import com.github.gfx.android.orma.annotation.StaticTypeAdapter;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.TypeName;
+
+import android.support.annotation.Nullable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Currency;
+import java.util.UUID;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+public class TypeAdapterDefinition {
+
+    public static TypeAdapterDefinition[] BUILTINS = {
+            TypeAdapterDefinition.make(BigDecimal.class, String.class),
+            TypeAdapterDefinition.make(BigInteger.class, String.class),
+            TypeAdapterDefinition.make(Currency.class, String.class),
+            TypeAdapterDefinition.make(java.util.Date.class, long.class),
+            TypeAdapterDefinition.make(java.sql.Date.class, String.class, "SqlDate"),
+            TypeAdapterDefinition.make(java.sql.Time.class, String.class, "SqlTime"),
+            TypeAdapterDefinition.make(java.sql.Timestamp.class, String.class, "SqlTimestamp"),
+            TypeAdapterDefinition.make(Types.getList(Types.String), String.class, "StringList"),
+            TypeAdapterDefinition.make(Types.getSet(Types.String), String.class, "StringSet"),
+            TypeAdapterDefinition.make(ClassName.get("android.net", "Uri"), String.class),
+            TypeAdapterDefinition.make(UUID.class, String.class),
+    };
+
+    @Nullable
+    public final TypeElement element;
+
+    public final ClassName typeAdapterImpl;
+
+    public final TypeName targetType;
+
+    public final TypeName serializedType;
+
+    public final String serializer;
+
+    public final String deserializer;
+
+    public static TypeAdapterDefinition make(Class<?> targetType, Class<?> serializedType) {
+        return TypeAdapterDefinition.make(TypeName.get(targetType), TypeName.get(serializedType), targetType.getSimpleName());
+    }
+    public static TypeAdapterDefinition make(ClassName targetType, Class<?> serializedType) {
+        return TypeAdapterDefinition.make(targetType, TypeName.get(serializedType), targetType.simpleName());
+    }
+
+    public static TypeAdapterDefinition make(Class<?> targetType, Class<?> serializedType, String typeId) {
+        return TypeAdapterDefinition.make(TypeName.get(targetType), serializedType, typeId);
+    }
+
+    public static TypeAdapterDefinition make(TypeName targetType, Class<?> serializedType, String typeId) {
+        return TypeAdapterDefinition.make(targetType, TypeName.get(serializedType), typeId);
+    }
+
+    public static TypeAdapterDefinition make(TypeName targetType, TypeName serializedType, String typeId) {
+        return new TypeAdapterDefinition(Types.BuiltInSerializers, targetType, serializedType,
+                "serialize" + typeId, "deserialize" + typeId);
+    }
+
+    public TypeAdapterDefinition(Element element) {
+        this.element = (TypeElement) element;
+        this.typeAdapterImpl = ClassName.get(this.element);
+
+        StaticTypeAdapter annotation = element.getAnnotation(StaticTypeAdapter.class);
+
+        targetType =  TypeName.get(annotation.targetType());
+        serializedType = TypeName.get(annotation.serializedType());
+        serializer = annotation.serializer();
+        deserializer = annotation.deserializer();
+
+    }
+
+    public TypeAdapterDefinition(ClassName typeAdapter, TypeName targetType, TypeName serializedType,
+            String serializer, String deserializer) {
+        this.element = null;
+        this.typeAdapterImpl = typeAdapter;
+        this.targetType = targetType;
+        this.serializedType = serializedType;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+    }
+
+    public String getSerializerName() {
+        return serializer;
+    }
+
+    public String getDeserializerName() {
+        return deserializer;
+    }
+}

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/TypeAdapterDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/TypeAdapterDefinition.java
@@ -24,6 +24,7 @@ import android.support.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.Currency;
 import java.util.UUID;
 
@@ -36,6 +37,7 @@ public class TypeAdapterDefinition {
     public static TypeAdapterDefinition[] BUILTINS = {
             TypeAdapterDefinition.make(BigDecimal.class, String.class),
             TypeAdapterDefinition.make(BigInteger.class, String.class),
+            TypeAdapterDefinition.make(ByteBuffer.class, byte[].class),
             TypeAdapterDefinition.make(Currency.class, String.class),
             TypeAdapterDefinition.make(java.util.Date.class, long.class),
             TypeAdapterDefinition.make(java.sql.Date.class, String.class, "SqlDate"),

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/TypeAdapterDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/TypeAdapterDefinition.java
@@ -27,6 +27,7 @@ import java.math.BigInteger;
 import java.util.Currency;
 import java.util.UUID;
 
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -62,6 +63,7 @@ public class TypeAdapterDefinition {
     public static TypeAdapterDefinition make(Class<?> targetType, Class<?> serializedType) {
         return TypeAdapterDefinition.make(TypeName.get(targetType), TypeName.get(serializedType), targetType.getSimpleName());
     }
+
     public static TypeAdapterDefinition make(ClassName targetType, Class<?> serializedType) {
         return TypeAdapterDefinition.make(targetType, TypeName.get(serializedType), targetType.simpleName());
     }
@@ -84,13 +86,15 @@ public class TypeAdapterDefinition {
         this.typeAdapterImpl = ClassName.get(this.element);
 
         StaticTypeAdapter annotation = element.getAnnotation(StaticTypeAdapter.class);
+        AnnotationMirror annotationMirror = Mirrors.findAnnotationMirror(element, StaticTypeAdapter.class);
 
-        targetType =  TypeName.get(annotation.targetType());
-        serializedType = TypeName.get(annotation.serializedType());
+        // Can't access program class instances in annotation processing in , throwing MirroredTypeException
+        targetType =  TypeName.get(Mirrors.findAnnotationValueAsTypeMirror(annotationMirror, "targetType"));
+        serializedType = TypeName.get(Mirrors.findAnnotationValueAsTypeMirror(annotationMirror, "serializedType"));
         serializer = annotation.serializer();
         deserializer = annotation.deserializer();
-
     }
+
 
     public TypeAdapterDefinition(ClassName typeAdapter, TypeName targetType, TypeName serializedType,
             String serializer, String deserializer) {
@@ -108,5 +112,17 @@ public class TypeAdapterDefinition {
 
     public String getDeserializerName() {
         return deserializer;
+    }
+
+    @Override
+    public String toString() {
+        return "TypeAdapterDefinition{" +
+                "element=" + element +
+                ", typeAdapterImpl=" + typeAdapterImpl +
+                ", targetType=" + targetType +
+                ", serializedType=" + serializedType +
+                ", serializer='" + serializer + '\'' +
+                ", deserializer='" + deserializer + '\'' +
+                '}';
     }
 }

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/Types.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/Types.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class Types {
 
@@ -124,6 +125,8 @@ public class Types {
 
     public static final ClassName NoValueException = ClassName.get(ormaPackageName + ".exception", "NoValueException");
 
+    public static final ClassName BuiltInSerializers = ClassName.get(ormaPackageName, "BuiltInSerializers");
+
     // helper methods
 
     public static ParameterizedTypeName getCollection(TypeName type) {
@@ -160,6 +163,10 @@ public class Types {
 
     public static ParameterizedTypeName getDeleter(TypeName modelType, TypeName concleteDeleterType) {
         return ParameterizedTypeName.get(Deleter, modelType, concleteDeleterType);
+    }
+
+    public static ParameterizedTypeName getSet(ClassName typeName) {
+        return ParameterizedTypeName.get(ClassName.get(Set.class), typeName);
     }
 
     public static ParameterizedTypeName getList(TypeName typeName) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/UpdaterWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/UpdaterWriter.java
@@ -125,10 +125,9 @@ public class UpdaterWriter extends BaseWriter {
                                         ParameterSpec.builder(r.modelType, column.name)
                                                 .build()
                                 )
-                                .addStatement("contents.put($S, $L.$L)",
+                                .addStatement("contents.put($S, $L)",
                                         sql.quoteIdentifier(column.columnName),
-                                        column.name,
-                                        modelSchema.getPrimaryKey().buildGetColumnExpr())
+                                        modelSchema.getPrimaryKey().buildGetColumnExpr(column.name))
                                 .addStatement("return this")
                                 .build()
                 );


### PR DESCRIPTION
#49 

This PR should be compatible with v1.0.

Dynamic type adapters will be removed in v2.0

## New Features

* The best-matched SQLite storage type is adapted
  * e.g. `INTEGER` for `java.util.Date`, `BLOB` for `java.nio.ByteBuffer`
* Custom binary classes (e.g. `ByteBuffer`, `Bitmap`) are handled correctly
  * v1.0.0 can't use binary objects except for `byte[]`
