### PR TITLE
use RetentionPolicy.CLASS for kapt bugs

### DIFF
--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/Column.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/Column.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target({ElementType.FIELD})
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface Column {
 
     /**

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/Getter.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/Getter.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target({ElementType.PARAMETER, ElementType.METHOD})
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface Getter {
 
     /**

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/OnConflict.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/OnConflict.java
@@ -33,7 +33,7 @@ import java.lang.annotation.RetentionPolicy;
         OnConflict.REPLACE,
         OnConflict.ROLLBACK,
 })
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface OnConflict {
 
     int NONE = 0;

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/PrimaryKey.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/PrimaryKey.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target({ElementType.FIELD, ElementType.METHOD})
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface PrimaryKey {
 
     /**

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/Setter.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/Setter.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.CONSTRUCTOR})
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface Setter {
 
     /**

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/StaticTypeAdapter.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * {@link StaticTypeAdapter} defines how a type is stored in a database column.
  */
 @Target({ElementType.TYPE})
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface StaticTypeAdapter {
 
     /**

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/Table.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/Table.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface Table {
 
     /**

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/VirtualTable.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/VirtualTable.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * See https://www.sqlite.org/fts3.html for details.
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface VirtualTable {
 
     /**


### PR DESCRIPTION
Kapt uses class files as binary stubs, which do not include `RetentionPolicy.SOUCE` annotations.

This is described in http://blog.jetbrains.com/kotlin/2015/06/better-annotation-processing-supporting-stubs-in-kapt/ and should be removed in a future version.

Thanks to @sys1yagi to blog this issue: http://sys1yagi.hatenablog.com/entry/2016/02/02/130402 (ja)