### PR TITLE
implements SingleAssociationTypeAdapterFactory for Gson

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile 'io.reactivex:rxjava:1.1.0'
     compile 'com.android.support:support-annotations:23.1.1'
     provided 'com.android.support:recyclerview-v7:23.1.1'
+    provided 'com.google.code.gson:gson:2.5'
     testApt project(':processor')
     testCompile 'com.github.gfx.android.robolectricinstrumentation:robolectric-instrumentation:3.0.6'
     testCompile 'junit:junit:4.12'

--- a/library/src/main/java/com/github/gfx/android/orma/SingleAssociation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/SingleAssociation.java
@@ -67,6 +67,10 @@ public class SingleAssociation<Model> {
         return new SingleAssociation<>(id, model);
     }
 
+    public static <T> SingleAssociation<T> just(@NonNull  Schema<T> schema, @NonNull T model) {
+        return new SingleAssociation<>((long)(Object)schema.getPrimaryKey().get(model), model);
+    }
+
     public static <T> SingleAssociation<T> id(final long id) {
         return new SingleAssociation<>(id, Single.create(new Single.OnSubscribe<T>() {
             @Override
@@ -80,9 +84,26 @@ public class SingleAssociation<Model> {
         return id;
     }
 
+    @Deprecated
     @NonNull
     public Single<Model> single() {
         return single;
+    }
+
+    @NonNull
+    public Single<Model> observable() {
+        return single;
+    }
+
+    /**
+     * A shortcut of {@code singleAssociation.single().toBlocking().value()}.
+     *
+     * @return A model value the {@code SingleAssociation<T>} refers to.
+     * @throws NoValueException
+     */
+    @NonNull
+    public Model value() throws NoValueException {
+        return single.toBlocking().value();
     }
 
     @Override

--- a/library/src/main/java/com/github/gfx/android/orma/gson/SingleAssociationTypeAdapterFactory.java
+++ b/library/src/main/java/com/github/gfx/android/orma/gson/SingleAssociationTypeAdapterFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import com.github.gfx.android.orma.DatabaseHandle;
+import com.github.gfx.android.orma.Schema;
+import com.github.gfx.android.orma.SingleAssociation;
+
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+
+/**
+ * A Gson {@link TypeAdapterFactory} to handle Orma {@link SingleAssociation}.
+ */
+public class SingleAssociationTypeAdapterFactory implements TypeAdapterFactory {
+
+    final DatabaseHandle orma;
+
+    public SingleAssociationTypeAdapterFactory(@NonNull DatabaseHandle orma) {
+        this.orma = orma;
+    }
+
+    @NonNull
+    Schema<?> findSchema(Class<?> modelClass) {
+        for (Schema<?> schema : orma.getSchemas()) {
+            if (schema.getModelClass().equals(modelClass)) {
+                return schema;
+            }
+        }
+        throw new RuntimeException("No schema found for " + modelClass);
+    }
+
+    @SuppressWarnings("raw")
+    @Override
+    public <T> TypeAdapter<T> create(final Gson gson, TypeToken<T> typeToken) {
+        if (!typeToken.getRawType().isAssignableFrom(SingleAssociation.class)) {
+            return null;
+        }
+        if (!(typeToken.getType() instanceof ParameterizedType)) {
+            throw new ClassCastException("Expected a parameterized SingleAssociation<T>, but got " + typeToken.getType());
+        }
+
+        final Class<?> modelType = (Class<?>) ((ParameterizedType) typeToken.getType())
+                .getActualTypeArguments()[0];
+
+        final Schema schema = findSchema(modelType);
+
+        return new TypeAdapter<T>() {
+
+            @Override
+            public void write(JsonWriter out, T value) throws IOException {
+                SingleAssociation<?> association = (SingleAssociation<?>) value;
+                gson.toJson(association.value(), modelType, out);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public T read(JsonReader in) throws IOException {
+                Object model = gson.fromJson(in, modelType);
+                return (T) SingleAssociation.just(schema, model);
+            }
+        };
+    }
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/GsonTypeAdapterTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/GsonTypeAdapterTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import com.github.gfx.android.orma.ModelFactory;
+import com.github.gfx.android.orma.SingleAssociation;
+import com.github.gfx.android.orma.gson.SingleAssociationTypeAdapterFactory;
+import com.github.gfx.android.orma.test.model.Book;
+import com.github.gfx.android.orma.test.model.OrmaDatabase;
+import com.github.gfx.android.orma.test.model.Publisher;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.annotation.NonNull;
+import android.support.test.runner.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(AndroidJUnit4.class)
+public class GsonTypeAdapterTest {
+
+    OrmaDatabase db;
+
+    Publisher publisher;
+
+    Gson gson;
+
+    @Before
+    public void setUp() throws Exception {
+
+        db = OrmaFactory.create();
+
+        gson = new GsonBuilder()
+                .registerTypeAdapterFactory(new SingleAssociationTypeAdapterFactory(db))
+                .create();
+
+        publisher = db.createPublisher(new ModelFactory<Publisher>() {
+            @NonNull
+            @Override
+            public Publisher call() {
+                Publisher publisher = new Publisher();
+                publisher.name = "foo bar";
+                publisher.startedYear = 2015;
+                publisher.startedMonth = 12;
+
+                return publisher;
+            }
+        });
+
+        db.createBook(new ModelFactory<Book>() {
+            @NonNull
+            @Override
+            public Book call() {
+                Book book = new Book();
+                book.title = "today";
+                book.content = "milk, banana";
+                book.inPrint = true;
+                book.publisher = SingleAssociation.id(publisher.id);
+                return book;
+            }
+        });
+    }
+
+    @Test
+    public void serializeAndDeserialize() throws Exception {
+        Book originalBook = db.selectFromBook().value();
+
+        String json = gson.toJson(originalBook);
+        Book book = gson.fromJson(json, Book.class);
+
+        assertThat(book.bookId, is(originalBook.bookId));
+        assertThat(book.title, is(originalBook.title));
+        assertThat(book.publisher.getId(), is(publisher.id));
+        assertThat(book.publisher.value().name, is(publisher.name));
+    }
+}


### PR DESCRIPTION
NOTE: Orma does not have a dependency to Gson. It is still optional.