### PR TITLE
withoutAutoId option for UPSERT operations

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
@@ -17,7 +17,6 @@ package com.github.gfx.android.orma;
 
 import com.github.gfx.android.orma.adapter.TypeAdapter;
 import com.github.gfx.android.orma.adapter.TypeAdapterRegistry;
-import com.github.gfx.android.orma.annotation.OnConflict;
 import com.github.gfx.android.orma.exception.DatabaseAccessOnMainThreadException;
 import com.github.gfx.android.orma.migration.MigrationEngine;
 import com.github.gfx.android.orma.migration.sqliteparser.SQLiteParserUtils;
@@ -154,7 +153,7 @@ public class OrmaConnection extends SQLiteOpenHelper {
     }
 
     public <T> T createModel(Schema<T> schema, ModelFactory<T> factory) {
-        Inserter<T> sth = new Inserter<>(this, schema, schema.getInsertStatement(OnConflict.NONE));
+        Inserter<T> sth = new Inserter<>(this, schema);
         long id = sth.execute(factory.call());
 
         ColumnDef<T, ?> primaryKey = schema.getPrimaryKey();

--- a/library/src/main/java/com/github/gfx/android/orma/Relation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Relation.java
@@ -16,6 +16,7 @@
 package com.github.gfx.android.orma;
 
 import com.github.gfx.android.orma.annotation.OnConflict;
+import com.github.gfx.android.orma.annotation.PrimaryKey;
 import com.github.gfx.android.orma.internal.OrmaConditionBase;
 
 import android.database.sqlite.SQLiteQueryBuilder;
@@ -218,12 +219,32 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
 
     @NonNull
     public Inserter<Model> inserter() {
-        return inserter(OnConflict.NONE);
+        return inserter(OnConflict.NONE, true);
     }
 
     @NonNull
     public Inserter<Model> inserter(@OnConflict int onConflictAlgorithm) {
-        return new Inserter<>(conn, schema, schema.getInsertStatement(onConflictAlgorithm));
+        return new Inserter<>(conn, schema, onConflictAlgorithm, true);
+    }
+
+    /**
+     * @param onConflictAlgorithm {@link OnConflict} algorithm
+     * @param withoutAutoId if true, {@link PrimaryKey#auto()} is omitted in the {@code INSERT} statement.
+     * @return An {@link Inserter} instance, or a prepared statement to {@code INSERT}.
+     */
+    @NonNull
+    public Inserter<Model> inserter(@OnConflict int onConflictAlgorithm, boolean withoutAutoId) {
+        return new Inserter<>(conn, schema, onConflictAlgorithm, withoutAutoId);
+    }
+
+    /**
+     * Equivalent to {@code relation.inserter(OnConflict.REPLACE, false)}.
+     *
+     * @return An {@code Inserter} instance to upsert rows.
+     */
+    @NonNull
+    public Inserter<Model> upserter() {
+        return inserter(OnConflict.REPLACE, false);
     }
 
     // Iterator<Model>

--- a/library/src/main/java/com/github/gfx/android/orma/Schema.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Schema.java
@@ -54,11 +54,12 @@ public interface Schema<Model> extends MigrationSchema {
     List<String> getCreateIndexStatements();
 
     @NonNull
-    String getInsertStatement(@OnConflict int onConflictAlgorithm);
+    String getInsertStatement(@OnConflict int onConflictAlgorithm, boolean withoutAutoId);
 
-    Object[] convertToArgs(@NonNull OrmaConnection conn, @NonNull Model model);
+    Object[] convertToArgs(@NonNull OrmaConnection conn, @NonNull Model mode, boolean withoutAutoId);
 
-    void bindArgs(@NonNull OrmaConnection conn, @NonNull SQLiteStatement statement, @NonNull Model model);
+    void bindArgs(@NonNull OrmaConnection conn, @NonNull SQLiteStatement statement, @NonNull Model model,
+            boolean withoutAutoId, int offset);
 
     @NonNull
     Model newModelFromCursor(@NonNull OrmaConnection conn, @NonNull Cursor cursor);

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
@@ -636,6 +636,15 @@ public class QueryTest {
     }
 
     @Test
+    public void upsertWithPrimaryKey() throws Exception {
+        Book book = db.selectFromBook().value();
+        book.content = "modified";
+        db.prepareInsertIntoBook(OnConflict.REPLACE, false).execute(book);
+        assertThat(db.selectFromBook().bookIdEq(book.bookId).value().content, is("modified"));
+    }
+
+
+    @Test
     public void inserterExecuteAll() throws Exception {
         Inserter<Book> inserter = db.prepareInsertIntoBook();
         inserter.executeAll(someBooks());

--- a/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
@@ -45,8 +45,9 @@ public class SchemaTest {
         assertThat(PublisherSchema.startedYear.name, is("started_year"));
         assertThat(PublisherSchema.startedMonth.name, is("started_month"));
 
-        assertThat(schema.getCreateTableStatement(), is(
-                "CREATE TABLE \"publishers\" (\"id\" INTEGER PRIMARY KEY AUTOINCREMENT, \"name\" TEXT UNIQUE NOT NULL, \"started_year\" INTEGER NOT NULL, \"started_month\" INTEGER NOT NULL)"
+        assertThat("PRIMARY KEY is placed in the last",
+                schema.getCreateTableStatement(), is(
+                "CREATE TABLE \"publishers\" (\"name\" TEXT UNIQUE NOT NULL, \"started_year\" INTEGER NOT NULL, \"started_month\" INTEGER NOT NULL, \"id\" INTEGER PRIMARY KEY AUTOINCREMENT)"
         ));
     }
 

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/DatabaseWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/DatabaseWriter.java
@@ -332,7 +332,7 @@ public class DatabaseWriter extends BaseWriter {
                                     schema.getModelClassName())
                             .addModifiers(Modifier.PUBLIC)
                             .returns(Types.getInserter(schema.getModelClassName()))
-                            .addStatement("return prepareInsertInto$L($T.NONE)",
+                            .addStatement("return prepareInsertInto$L($T.NONE, true)",
                                     simpleModelName,
                                     OnConflict.class
                             )
@@ -347,13 +347,29 @@ public class DatabaseWriter extends BaseWriter {
                                     .addAnnotation(OnConflict.class)
                                     .build())
                             .returns(Types.getInserter(schema.getModelClassName()))
-                            .addStatement("return new $T($L, $L, $L.getInsertStatement(onConflictAlgorithm))",
+                            .addStatement("return prepareInsertInto$L(onConflictAlgorithm, true)",
+                                    simpleModelName
+                            )
+                            .build());
+
+            methodSpecs.add(
+                    MethodSpec.methodBuilder("prepareInsertInto" + simpleModelName)
+                            .addJavadoc("Create a prepared statement for {@code INSERT OR ... INTO $T ...}.\n",
+                                    schema.getModelClassName())
+                            .addModifiers(Modifier.PUBLIC)
+                            .addParameter(ParameterSpec.builder(int.class, "onConflictAlgorithm")
+                                    .addAnnotation(OnConflict.class)
+                                    .build())
+                            .addParameter(ParameterSpec.builder(boolean.class, "withoutAutoId")
+                                    .build())
+                            .returns(Types.getInserter(schema.getModelClassName()))
+                            .addStatement("return new $T($L, $L, onConflictAlgorithm, withoutAutoId)",
                                     Types.getInserter(schema.getModelClassName()),
                                     connection,
-                                    schemaInstance,
                                     schemaInstance
                             )
                             .build());
+
         });
 
         return methodSpecs;


### PR DESCRIPTION
`withoutAutoId` is added to `Inserter#<init>` as a low-level interface to UPSERT.

`Inserter<T> Relation#upserter()` is added as a high-level interface to UPSERT.