### PR TITLE
remove deprecated methods and fix inconsistent methods

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/Selector.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Selector.java
@@ -31,6 +31,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import rx.Observable;
+import rx.Single;
+import rx.SingleSubscriber;
 import rx.Subscriber;
 import rx.functions.Action1;
 import rx.functions.FuncN;
@@ -153,23 +155,17 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
      * @return An observable that yields {@link #count()}.
      */
     @NonNull
-    public Observable<Integer> countAsObservable() {
-        return Observable.create(new Observable.OnSubscribe<Integer>() {
+    public Single<Integer> countAsObservable() {
+        return Single.create(new Single.OnSubscribe<Integer>() {
             @Override
-            public void call(Subscriber<? super Integer> subscriber) {
-                subscriber.onNext(count());
-                subscriber.onCompleted();
+            public void call(SingleSubscriber<? super Integer> singleSubscriber) {
+                singleSubscriber.onSuccess(count());
             }
         });
     }
 
     public boolean isEmpty() {
         return count() == 0;
-    }
-
-    @Deprecated // TODO: remove it in v2.0
-    public boolean empty() {
-        return isEmpty();
     }
 
     @Nullable

--- a/library/src/main/java/com/github/gfx/android/orma/SingleAssociation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/SingleAssociation.java
@@ -98,19 +98,13 @@ public class SingleAssociation<Model> implements Parcelable {
         return id;
     }
 
-    @Deprecated
-    @NonNull
-    public Single<Model> single() {
-        return single;
-    }
-
     @NonNull
     public Single<Model> observable() {
         return single;
     }
 
     /**
-     * A shortcut of {@code singleAssociation.single().toBlocking().value()}.
+     * A shortcut of {@code singleAssociation.observable().toBlocking().value()}.
      *
      * @return A model value the {@code SingleAssociation<T>} refers to.
      */

--- a/library/src/test/java/com/github/gfx/android/orma/test/ForeignKeysTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ForeignKeysTest.java
@@ -86,7 +86,7 @@ public class ForeignKeysTest {
 
     @Test
     public void testHasOne() throws Exception {
-        Publisher publisher = db.selectFromBook().value().publisher.single().toBlocking().value();
+        Publisher publisher = db.selectFromBook().value().publisher.observable().toBlocking().value();
         assertThat(publisher.name, is("foo bar"));
         assertThat(publisher.startedYear, is(2015));
         assertThat(publisher.startedMonth, is(12));
@@ -168,7 +168,7 @@ public class ForeignKeysTest {
         assertThat(count, is(1));
 
         Book book = db.selectFromBook().where("title = ?", "today").value();
-        assertThat(book.publisher.single().toBlocking().value().name, is("The Nova"));
+        assertThat(book.publisher.observable().toBlocking().value().name, is("The Nova"));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class ForeignKeysTest {
         assertThat(count, is(1));
 
         Book book = db.selectFromBook().where("title = ?", "today").value();
-        assertThat(book.publisher.single().toBlocking().value().name, is("The Nova"));
+        assertThat(book.publisher.observable().toBlocking().value().name, is("The Nova"));
     }
 
     @Test(expected = SQLiteException.class)

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
@@ -110,12 +110,12 @@ public class QueryTest {
 
     @Test
     public void empty() throws Exception {
-        assertThat(db.selectFromBook().empty(), is(false));
+        assertThat(db.selectFromBook().isEmpty(), is(false));
     }
 
     @Test
     public void countAsObservable() throws Exception {
-        assertThat(db.selectFromBook().countAsObservable().toBlocking().single(), is(2));
+        assertThat(db.selectFromBook().countAsObservable().toBlocking().value(), is(2));
     }
 
     @Test


### PR DESCRIPTION
#168 

* Remove `Selector#empty()`; use `#isEmpty()` instead
* Remove `SingleAssociation#single()`; use `#observable()` instead
* Change `Observable<Integer> countAsObservable()` to `Single<Integer> countAsObservable()` for consistency