### PR TITLE
Fixed ArrayIndexOutOfBoundsException with convertToArgs()

### DIFF
--- a/processor/src/main/java/com/github/gfx/android/orma/processor/model/SchemaDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/model/SchemaDefinition.java
@@ -93,7 +93,9 @@ public class SchemaDefinition {
         // Places primaryKey as the last in columns to handle withoutAutoId.
         // See also the bindArgs() generator in SchemaWriter.
         columns.sort((a, b) -> {
-            if (a.primaryKey || b.primaryKey) {
+            if (a.primaryKey) {
+                return 1;
+            } else if (b.primaryKey) {
                 return -1;
             }
             return 0;


### PR DESCRIPTION
I fixed the bad comparator of columns in SchemaDefinition.

Sorting of columns has the purpose which is `Places primaryKey as the last in columns to handle withoutAutoId.`

However, given comparator is not correct.
If the `@PrimaryKey` column is not the first field, it will be moved to the first element of `columns`.

In addition, when PrimaryKey.auto is declared as `true`, `convertToArgs()` always throws `ArrayIndexOutOfBoundsException`.

Sort check program is following.
http://ideone.com/wn4fBv

The new comparator has the pre-condition -- `One table can have one PrimaryKey at most. `