### PR TITLE
fix #220 schmea validators raise errors in model inheritance

### DIFF
--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithInheritanceWIthoutColumns.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithInheritanceWIthoutColumns.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.model;
+
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ModelWithInheritanceWithoutColumns extends BaseModel {
+
+}

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/OrmaProcessor.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/OrmaProcessor.java
@@ -127,19 +127,17 @@ public class OrmaProcessor extends AbstractProcessor {
     }
 
     public Stream<SchemaDefinition> buildTableSchemas(ProcessingContext context, RoundEnvironment roundEnv) {
-        SchemaValidator validator = new SchemaValidator(context);
         return roundEnv
                 .getElementsAnnotatedWith(Table.class)
                 .stream()
-                .map(element -> new SchemaDefinition(context, validator.validate(element)));
+                .map(element -> new SchemaDefinition(context, (TypeElement) element));
     }
 
     public Stream<SchemaDefinition> buildVirtualTableSchemas(ProcessingContext context, RoundEnvironment roundEnv) {
-        SchemaValidator validator = new SchemaValidator(context);
         return roundEnv
                 .getElementsAnnotatedWith(VirtualTable.class)
                 .stream()
-                .map(element -> new SchemaDefinition(context, validator.validate(element)));
+                .map(element -> new SchemaDefinition(context, (TypeElement) element));
     }
 
     public void writeCodeForEachModel(SchemaDefinition schema, BaseWriter writer) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/model/SchemaDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/model/SchemaDefinition.java
@@ -21,6 +21,7 @@ import com.github.gfx.android.orma.annotation.PrimaryKey;
 import com.github.gfx.android.orma.annotation.Setter;
 import com.github.gfx.android.orma.annotation.Table;
 import com.github.gfx.android.orma.processor.ProcessingContext;
+import com.github.gfx.android.orma.processor.SchemaValidator;
 import com.github.gfx.android.orma.processor.util.Strings;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -103,6 +104,8 @@ public class SchemaDefinition {
 
         this.primaryKey = findPrimaryKey(columns);
         this.constructorElement = findConstructor(context, typeElement);
+
+        SchemaValidator.validate(context, this);
     }
 
     /**


### PR DESCRIPTION
Let SchemaValidator work for `SchemaDefinition`, instead of `TypeElement`, to handle inherited models easily.