### PR TITLE
Avoid crash when relation have where clauses

### DIFF
--- a/example/src/main/java/com/github/gfx/android/orma/example/activity/RecyclerViewActivity.java
+++ b/example/src/main/java/com/github/gfx/android/orma/example/activity/RecyclerViewActivity.java
@@ -65,7 +65,7 @@ public class RecyclerViewActivity extends AppCompatActivity {
                 .readOnMainThread(AccessThreadConstraint.NONE)
                 .build();
 
-        adapter = new Adapter(this, orma.relationOfTodo().orderByCreatedTimeAsc());
+        adapter = new Adapter(this, orma.relationOfTodo().doneEq(true).orderByCreatedTimeAsc());
         binding.list.setAdapter(adapter);
 
         binding.fab.setOnClickListener(new View.OnClickListener() {
@@ -80,6 +80,7 @@ public class RecyclerViewActivity extends AppCompatActivity {
                         todo.title = "RecyclerView item #" + number;
                         todo.content = ZonedDateTime.now().toString();
                         todo.createdTime = new Date();
+                        todo.done = System.currentTimeMillis() % 2 == 0;
                         return todo;
                     }
                 })

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
@@ -42,12 +42,9 @@ public class OrmaAdapter<Model> {
 
     final Handler handler = new Handler(Looper.getMainLooper());
 
-    int totalCount = 0;
-
     public OrmaAdapter(@NonNull Context context, @NonNull Relation<Model, ?> relation) {
         this.context = context;
         this.relation = relation;
-        totalCount = relation.selector().count();
     }
 
     @NonNull
@@ -61,7 +58,7 @@ public class OrmaAdapter<Model> {
     }
 
     public int getItemCount() {
-        return totalCount;
+        return relation.selector().count();
     }
 
     @SuppressWarnings("unchecked")
@@ -90,7 +87,6 @@ public class OrmaAdapter<Model> {
                 .doOnSuccess(new Action1<Long>() {
                     @Override
                     public void call(Long rowId) {
-                        totalCount++;
                     }
                 });
     }
@@ -101,7 +97,6 @@ public class OrmaAdapter<Model> {
                 .doOnNext(new Action1<Integer>() {
                     @Override
                     public void call(final Integer deletedPosition) {
-                        totalCount--;
                     }
                 });
     }
@@ -113,7 +108,6 @@ public class OrmaAdapter<Model> {
                 .doOnSuccess(new Action1<Integer>() {
                     @Override
                     public void call(Integer deletedItems) {
-                        totalCount = 0;
                     }
                 });
     }


### PR DESCRIPTION
If OrmaRecyclerViewAdapter's relation have where clauses, app crashed on additemAsObservable() when inserted data is not match where clauses.
See issue #227 

But this is not cool.
Because query of to get records count is executed on every addItemAsObservable.