### PR TITLE
Pararell annotation processing

### DIFF
--- a/processor/src/main/java/com/github/gfx/android/orma/processor/OrmaProcessor.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/OrmaProcessor.java
@@ -156,12 +156,14 @@ public class OrmaProcessor extends AbstractProcessor {
         }
     }
 
-    private synchronized JavaFileObject createSourceFile(JavaFile javaFile, Filer filer) throws IOException {
+    private JavaFileObject createSourceFile(JavaFile javaFile, Filer filer) throws IOException {
         String fileName = javaFile.packageName.isEmpty()
                 ? javaFile.typeSpec.name
                 : javaFile.packageName + "." + javaFile.typeSpec.name;
         List<Element> originatingElements = javaFile.typeSpec.originatingElements;
-        return filer.createSourceFile(fileName, originatingElements.toArray(new Element[originatingElements.size()]));
+        synchronized (this) {
+            return filer.createSourceFile(fileName, originatingElements.toArray(new Element[originatingElements.size()]));
+        }
     }
 
     private void writeTo(JavaFile javaFile, Filer filer) throws IOException {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
@@ -52,6 +52,8 @@ public class ProcessingContext {
 
     public final SqlGenerator sqlg;
 
+    public final boolean debug = isDebugging();
+
     public ProcessingContext(ProcessingEnvironment processingEnv) {
         this.processingEnv = processingEnv;
         this.schemaMap = new LinkedHashMap<>(); // the order matters
@@ -112,8 +114,16 @@ public class ProcessingContext {
         return schemaMap.values().iterator().next();
     }
 
-    public boolean isDebugging() {
+    private static boolean isDebugging() {
         String debug = System.getProperty("orma.debug", "true");
         return !Strings.isEmpty(debug) && !debug.equals("0") && !debug.equalsIgnoreCase("false");
+    }
+
+    public void note(String message) {
+        if (debug) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE,
+                    "[OrmaProcessor] " + message);
+        }
+
     }
 }

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
@@ -122,7 +122,7 @@ public class ProcessingContext {
     public void note(String message) {
         if (debug) {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE,
-                    "[OrmaProcessor] " + message);
+                    "[" + OrmaProcessor.TAG + "] " + message);
         }
 
     }


### PR DESCRIPTION
As of JavaPoet 1.6.0, `JavaFile#writeTo(Filer)` is not thread-safe, so add a thread-safe version.