### PR TITLE
Improve OrmaAdapter

### DIFF
--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/OrmaDatabase.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/OrmaDatabase.java
@@ -3,6 +3,7 @@ package com.github.gfx.android.orma.example.orma;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteConstraintException;
+import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 import com.github.gfx.android.orma.DatabaseHandle;
@@ -16,6 +17,7 @@ import com.github.gfx.android.orma.annotation.OnConflict;
 import com.github.gfx.android.orma.exception.TransactionAbortException;
 import java.util.Arrays;
 import java.util.List;
+import rx.Completable;
 
 /**
  * <p>The Orma database handle class.</p>
@@ -68,21 +70,44 @@ public class OrmaDatabase implements DatabaseHandle {
     return connection;
   }
 
+  @Deprecated
   @WorkerThread
   public void transactionSync(@NonNull TransactionTask task) throws TransactionAbortException {
     connection.transactionSync(task);
   }
 
+  @WorkerThread
+  public void transactionSync(@NonNull Runnable task) {
+    connection.transactionSync(task);
+  }
+
+  @Deprecated
   public void transactionAsync(@NonNull TransactionTask task) {
     connection.transactionAsync(task);
   }
 
+  @CheckResult
+  public Completable transactionAsync(@NonNull Runnable task) {
+    return connection.transactionAsync(task);
+  }
+
+  @Deprecated
   public void transactionNonExclusiveSync(@NonNull TransactionTask task) throws TransactionAbortException {
     connection.transactionNonExclusiveSync(task);
   }
 
+  public void transactionNonExclusiveSync(@NonNull Runnable task) {
+    connection.transactionNonExclusiveSync(task);
+  }
+
+  @Deprecated
   public void transactionNonExclusiveAsync(@NonNull TransactionTask task) {
     connection.transactionNonExclusiveAsync(task);
+  }
+
+  @CheckResult
+  public Completable transactionNonExclusiveAsync(@NonNull Runnable task) {
+    return connection.transactionNonExclusiveAsync(task);
   }
 
   /**

--- a/example/src/main/java/com/github/gfx/android/orma/example/activity/BenchmarkActivity.java
+++ b/example/src/main/java/com/github/gfx/android/orma/example/activity/BenchmarkActivity.java
@@ -214,9 +214,9 @@ public class BenchmarkActivity extends AppCompatActivity {
             public void call(SingleSubscriber<? super Result> subscriber) {
                 long t0 = System.currentTimeMillis();
 
-                orma.transactionSync(new TransactionTask() {
+                orma.transactionSync(new Runnable() {
                     @Override
-                    public void execute() throws Exception {
+                    public void run() {
                         long now = System.currentTimeMillis();
 
                         Inserter<Todo> statement = orma.prepareInsertIntoTodo();

--- a/library/src/main/java/com/github/gfx/android/orma/Relation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Relation.java
@@ -150,9 +150,9 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
         return Observable.create(new Observable.OnSubscribe<Integer>() {
             @Override
             public void call(final Subscriber<? super Integer> subscriber) {
-                conn.transactionSync(new TransactionTask() {
+                conn.transactionAsync(new Runnable() {
                     @Override
-                    public void execute() throws Exception {
+                    public void run() {
                         int position = indexOf(item);
                         ColumnDef<Model, ?> pk = schema.getPrimaryKey();
                         int deletedRows = deleter()
@@ -162,14 +162,8 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
                         if (deletedRows > 0) {
                             subscriber.onNext(position);
                         }
-                        subscriber.onCompleted();
                     }
-
-                    @Override
-                    public void onError(@NonNull Exception exception) {
-                        subscriber.onError(exception);
-                    }
-                });
+                }).subscribe(subscriber);
             }
         });
     }

--- a/library/src/main/java/com/github/gfx/android/orma/Relation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Relation.java
@@ -83,10 +83,19 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
     }
 
     @NonNull
+    public Model value() {
+        return selector().value();
+    }
+
+    @Nullable
+    public Model valueOrNull() {
+        return selector().valueOrNull();
+    }
+
+    @NonNull
     public Model get(@IntRange(from = 0) int position) {
         return selector().get(position);
     }
-
 
     @NonNull
     public Model getOrCreate(@IntRange(from = 0) long position, @NonNull ModelFactory<Model> factory) {

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
@@ -63,8 +63,8 @@ public class OrmaAdapter<Model> {
 
     @SuppressWarnings("unchecked")
     @NonNull
-    public <T extends Relation<Model, ?>> Relation<Model, T> getRelation() {
-        return (Relation<Model, T>) relation;
+    public <R extends Relation<Model, R>> R getRelation() {
+        return (R) relation.clone();
     }
 
     public void runOnUiThread(@NonNull final Runnable task) {

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
@@ -29,6 +29,7 @@ import android.view.LayoutInflater;
 
 import rx.Observable;
 import rx.Single;
+import rx.functions.Action0;
 import rx.functions.Action1;
 
 /**
@@ -108,9 +109,9 @@ public class OrmaAdapter<Model> {
     @NonNull
     public Observable<Integer> removeItemAsObservable(@NonNull final Model item) {
         return relation.deleteAsObservable(item)
-                .doOnNext(new Action1<Integer>() {
+                .doOnCompleted(new Action0() {
                     @Override
-                    public void call(Integer deletedRows) {
+                    public void call() {
                         count = -1;
                     }
                 });

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
@@ -29,7 +29,6 @@ import android.view.LayoutInflater;
 
 import rx.Observable;
 import rx.Single;
-import rx.functions.Action0;
 import rx.functions.Action1;
 
 /**
@@ -109,9 +108,9 @@ public class OrmaAdapter<Model> {
     @NonNull
     public Observable<Integer> removeItemAsObservable(@NonNull final Model item) {
         return relation.deleteAsObservable(item)
-                .doOnCompleted(new Action0() {
+                .doOnNext(new Action1<Integer>() {
                     @Override
-                    public void call() {
+                    public void call(Integer position) {
                         count = -1;
                     }
                 });

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaListAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaListAdapter.java
@@ -70,10 +70,11 @@ public abstract class OrmaListAdapter<Model> extends BaseAdapter {
         return delegate.getLayoutInflater();
     }
 
+
     @SuppressWarnings("unchecked")
     @NonNull
-    public <T extends Relation<Model, ?>> Relation<Model, T> getRelation() {
-        return delegate.getRelation();
+    public <R extends Relation<Model, R>> R getRelation() {
+        return (R) delegate.getRelation();
     }
 
     public void runOnUiThread(@NonNull Runnable task) {

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaRecyclerViewAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaRecyclerViewAdapter.java
@@ -65,8 +65,8 @@ public abstract class OrmaRecyclerViewAdapter<Model, VH extends RecyclerView.Vie
 
     @SuppressWarnings("unchecked")
     @NonNull
-    public <T extends Relation<Model, ?>> Relation<Model, T> getRelation() {
-        return delegate.getRelation();
+    public <R extends Relation<Model, R>> R getRelation() {
+        return (R) delegate.getRelation();
     }
 
     public void runOnUiThreadSync(@NonNull Runnable task) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/generator/DatabaseWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/generator/DatabaseWriter.java
@@ -248,9 +248,10 @@ public class DatabaseWriter extends BaseWriter {
 
         methodSpecs.add(
                 MethodSpec.methodBuilder("transactionSync")
+                        .addAnnotation(Annotations.deprecated())
+                        .addAnnotation(Annotations.workerThread())
                         .addException(Types.TransactionAbortException)
                         .addModifiers(Modifier.PUBLIC)
-                        .addAnnotation(Annotations.workerThread())
                         .addParameter(
                                 ParameterSpec.builder(Types.TransactionTask, "task")
                                         .addAnnotation(Annotations.nonNull())
@@ -260,7 +261,20 @@ public class DatabaseWriter extends BaseWriter {
         );
 
         methodSpecs.add(
+                MethodSpec.methodBuilder("transactionSync")
+                        .addAnnotation(Annotations.workerThread())
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameter(
+                                ParameterSpec.builder(Runnable.class, "task")
+                                        .addAnnotation(Annotations.nonNull())
+                                        .build())
+                        .addStatement("$L.transactionSync(task)", connection)
+                        .build()
+        );
+
+        methodSpecs.add(
                 MethodSpec.methodBuilder("transactionAsync")
+                        .addAnnotation(Annotations.deprecated())
                         .addModifiers(Modifier.PUBLIC)
                         .addParameter(
                                 ParameterSpec.builder(Types.TransactionTask, "task")
@@ -271,7 +285,21 @@ public class DatabaseWriter extends BaseWriter {
         );
 
         methodSpecs.add(
+                MethodSpec.methodBuilder("transactionAsync")
+                        .addAnnotation(Annotations.checkResult())
+                        .addModifiers(Modifier.PUBLIC)
+                        .returns(Types.Completable)
+                        .addParameter(
+                                ParameterSpec.builder(Runnable.class, "task")
+                                        .addAnnotation(Annotations.nonNull())
+                                        .build())
+                        .addStatement("return $L.transactionAsync(task)", connection)
+                        .build()
+        );
+
+        methodSpecs.add(
                 MethodSpec.methodBuilder("transactionNonExclusiveSync")
+                        .addAnnotation(Annotations.deprecated())
                         .addException(Types.TransactionAbortException)
                         .addModifiers(Modifier.PUBLIC)
                         .addParameter(
@@ -283,13 +311,39 @@ public class DatabaseWriter extends BaseWriter {
         );
 
         methodSpecs.add(
+                MethodSpec.methodBuilder("transactionNonExclusiveSync")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameter(
+                                ParameterSpec.builder(Runnable.class, "task")
+                                        .addAnnotation(Annotations.nonNull())
+                                        .build())
+                        .addStatement("$L.transactionNonExclusiveSync(task)", connection)
+                        .build()
+        );
+
+
+        methodSpecs.add(
                 MethodSpec.methodBuilder("transactionNonExclusiveAsync")
+                        .addAnnotation(Annotations.deprecated())
                         .addModifiers(Modifier.PUBLIC)
                         .addParameter(
                                 ParameterSpec.builder(Types.TransactionTask, "task")
                                         .addAnnotation(Annotations.nonNull())
                                         .build())
                         .addStatement("$L.transactionNonExclusiveAsync(task)", connection)
+                        .build()
+        );
+
+        methodSpecs.add(
+                MethodSpec.methodBuilder("transactionNonExclusiveAsync")
+                        .addAnnotation(Annotations.checkResult())
+                        .addModifiers(Modifier.PUBLIC)
+                        .returns(Types.Completable)
+                        .addParameter(
+                                ParameterSpec.builder(Runnable.class, "task")
+                                        .addAnnotation(Annotations.nonNull())
+                                        .build())
+                        .addStatement("return $L.transactionNonExclusiveAsync(task)", connection)
                         .build()
         );
 

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/util/Annotations.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/util/Annotations.java
@@ -35,6 +35,10 @@ public class Annotations {
 
     private static final AnnotationSpec nullable = AnnotationSpec.builder(Types.Nullable).build();
 
+    private static final AnnotationSpec checkResult = AnnotationSpec.builder(Types.CheckResult).build();
+
+    private static final AnnotationSpec deprecated = AnnotationSpec.builder(Deprecated.class).build();
+
     private static final List<AnnotationSpec> safeVarArgsAnnotations = Arrays.asList(
             AnnotationSpec.builder(SafeVarargs.class).build(),
             suppressWarnings("varargs")
@@ -101,5 +105,13 @@ public class Annotations {
             builder.addMember("value", "{$L}", names.build());
         }
         return builder.build();
+    }
+
+    public static AnnotationSpec deprecated() {
+        return deprecated;
+    }
+
+    public static AnnotationSpec checkResult() {
+        return checkResult;
     }
 }

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/util/Types.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/util/Types.java
@@ -70,6 +70,8 @@ public class Types {
 
     public static final ClassName WorkerThread = ClassName.get("android.support.annotation", "WorkerThread");
 
+    public static final ClassName CheckResult = ClassName.get("android.support.annotation", "CheckResult");
+
     public static final ClassName Single = ClassName.get("rx", "Single");
 
     public static final ClassName Observable = ClassName.get("rx", "Observable");
@@ -129,6 +131,8 @@ public class Types {
     public static final ClassName Schemas = ClassName.get(ormaPackageName + ".internal", "Schemas");
 
     public static final ClassName NullPointerException = ClassName.get(NullPointerException.class);
+
+    public static final ClassName Completable = ClassName.get("rx", "Completable");
 
     // helper methods
 


### PR DESCRIPTION
improve OrmaAdapter to evaluate use cases.

* make `getRelation()` return a clone
* fix the return type of `getRelation()`
* add `Relation#value()` as a shortcut of `relation.selector().value()`
* add `void transactionSync(Runnable)`
* add `Completable transactionAsync(Runnable)`