### PR TITLE
discard tunnelvisionlabs antlr; use org.antlr instead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.novoda:bintray-release:0.3.4' // https://github.com/novoda/bintray-release
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -62,10 +62,6 @@ android {
     }
 }
 
-configurations {
-    all*.exclude group: 'com.tunnelvisionlabs', module: 'antlr4-annotations'
-}
-
 dependencies {
     apt project(':processor')
     compile project(':library')

--- a/migration/build.gradle
+++ b/migration/build.gradle
@@ -58,12 +58,8 @@ task generateParserSources(type: JavaExec) {
 tasks.preBuild.dependsOn(generateParserSources)
 
 dependencies {
-    antlr 'com.tunnelvisionlabs:antlr4:4.5'
-    compile('com.tunnelvisionlabs:antlr4-runtime:4.5') {
-        exclude group: 'com.tunnelvisionlabs', module: 'antlr4-annotations'
-        exclude group: 'org.abego.treelayout', module: 'org.abego.treelayout.core'
-    }
-    provided 'com.tunnelvisionlabs:antlr4-annotations:4.5'
+    antlr 'org.antlr:antlr4:4.5.3'
+    compile('org.antlr:antlr4-runtime:4.5.3')
 
     compile "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
     testCompile 'com.github.gfx.android.robolectricinstrumentation:robolectric-instrumentation:3.0.8'


### PR DESCRIPTION
Resolve #256 

DataBinding 2.2 have got rid of tunnelvisionlabs antlr, so there is no reason to use it in this library.

See https://code.google.com/p/android/issues/detail?id=200925 for details

This PR will be merged after the stable release of Android Gradle Plugin 2.2.