### PR TITLE
Fix#265 generic superl classes caused compilation errors

### DIFF
--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithGenericSuperClass.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithGenericSuperClass.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.PrimaryKey;
+import com.github.gfx.android.orma.annotation.Table;
+
+class P<T> {
+    @PrimaryKey
+    long id;
+}
+
+@Table
+public class ModelWithGenericSuperClass extends P<String> {
+
+
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithGenerics.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithGenerics.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.model;
+
+import com.github.gfx.android.orma.annotation.PrimaryKey;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ModelWithGenerics<T> {
+
+    @PrimaryKey
+    long id;
+
+}

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/ProcessingContext.java
@@ -36,8 +36,10 @@ import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
+import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.tools.Diagnostic;
 
 public class ProcessingContext {
@@ -108,12 +110,21 @@ public class ProcessingContext {
         return getTypeElement(type).asType();
     }
 
-    public TypeElement getTypeElement(CharSequence name) {
-        return processingEnv.getElementUtils().getTypeElement(name);
+    public TypeElement getTypeElement(CharSequence fqName) {
+        TypeElement typeElement = processingEnv.getElementUtils().getTypeElement(fqName);
+        if (typeElement == null) {
+            throw new RuntimeException("No such class: " + fqName);
+        }
+        return typeElement;
     }
 
-    public TypeElement getTypeElement(TypeMirror name) {
-        return getTypeElement(name.toString());
+    public TypeElement getTypeElement(TypeMirror typeMirror) {
+        return typeMirror.accept(new SimpleTypeVisitor8<TypeElement, TypeMirror>() {
+            @Override
+            public TypeElement visitDeclared(DeclaredType declaredType, TypeMirror typeMirror) {
+                return (TypeElement)declaredType.asElement();
+            }
+        }, typeMirror);
     }
 
     public TypeElement getTypeElement(Type name) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/model/SchemaDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/model/SchemaDefinition.java
@@ -25,6 +25,7 @@ import com.github.gfx.android.orma.processor.util.Strings;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -182,11 +183,11 @@ public class SchemaDefinition {
     }
 
 
-    List<ColumnDefinition> collectColumns(TypeElement typeElement) {
+    List<ColumnDefinition> collectColumns(@NonNull TypeElement typeElement) {
         List<ColumnDefinition> columns = new ArrayList<>();
-
         TypeMirror superclass = typeElement.getSuperclass();
         if (!superclass.toString().equals(Object.class.getCanonicalName())) {
+            // superclass might represent  com.example.C<java.lang.String>
             TypeElement superclassElement = context.getTypeElement(superclass);
             columns.addAll(collectColumns(superclassElement));
         }


### PR DESCRIPTION
Note that you can't use type parameters for `@Column` because table definitions in SQLite can't be generic.

connect #265