### PR TITLE
upgrade RxJava to 1.1.7

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -36,7 +36,7 @@ android {
 dependencies {
     compile project(':migration')
     compile project(':annotations')
-    compile 'io.reactivex:rxjava:1.1.6'
+    compile 'io.reactivex:rxjava:1.1.7'
     compile "com.android.support:support-v4:${SUPPORT_LIBRARY_VERSION}"
     compile "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
     provided("com.android.support:recyclerview-v7:${SUPPORT_LIBRARY_VERSION}") {


### PR DESCRIPTION
Note that 1.1.7 includes breaking changes on `Completable`, which is marked as `@Experimental`.

See https://github.com/ReactiveX/RxJava/releases/tag/v1.1.7 for details.