### PR TITLE
use `$alias` in Schema, to avoid name conflicts with columns

### DIFF
--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Schema.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Schema.java
@@ -18,20 +18,20 @@ public class Category_Schema implements Schema<Category> {
   public static final Category_Schema INSTANCE = Schemas.register(new Category_Schema());
 
   @Nullable
-  public final String alias;
+  private final String $alias;
 
   public final ColumnDef<Category, String> name;
 
   public final ColumnDef<Category, Long> id;
 
-  private final String[] $DEFAULT_RESULT_COLUMNS;
+  private final String[] $defaultResultColumns;
 
   public Category_Schema() {
     this(null);
   }
 
   public Category_Schema(@Nullable Aliases.ColumnPath current) {
-    this.alias = current != null ? current.getAlias() : null;
+    $alias = current != null ? current.getAlias() : null;
     this.id = new ColumnDef<Category, Long>(this, "id", long.class, "INTEGER", ColumnDef.PRIMARY_KEY | ColumnDef.AUTO_VALUE) {
       @Override
       @NonNull
@@ -58,7 +58,7 @@ public class Category_Schema implements Schema<Category> {
         return model.name;
       }
     };
-    $DEFAULT_RESULT_COLUMNS = new String[]{
+    $defaultResultColumns = new String[]{
           name.getQualifiedName(),
           id.getQualifiedName()
         };
@@ -85,13 +85,13 @@ public class Category_Schema implements Schema<Category> {
   @Nullable
   @Override
   public String getTableAlias() {
-    return alias;
+    return $alias;
   }
 
   @Nullable
   @Override
   public String getEscapedTableAlias() {
-    return alias != null ? '`' + alias + '`' : null;
+    return $alias != null ? '`' + $alias + '`' : null;
   }
 
   @NonNull
@@ -118,7 +118,7 @@ public class Category_Schema implements Schema<Category> {
   @NonNull
   @Override
   public String[] getDefaultResultColumns() {
-    return $DEFAULT_RESULT_COLUMNS;
+    return $defaultResultColumns;
   }
 
   @NonNull

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Schema.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Schema.java
@@ -18,7 +18,7 @@ public class Item2_Schema implements Schema<Item2> {
   public static final Item2_Schema INSTANCE = Schemas.register(new Item2_Schema());
 
   @Nullable
-  public final String alias;
+  private final String $alias;
 
   public final AssociationDef<Item2, Category, Category_Schema> category1;
 
@@ -26,14 +26,14 @@ public class Item2_Schema implements Schema<Item2> {
 
   public final ColumnDef<Item2, String> name;
 
-  private final String[] $DEFAULT_RESULT_COLUMNS;
+  private final String[] $defaultResultColumns;
 
   public Item2_Schema() {
     this(new Aliases().createPath("Item2"));
   }
 
   public Item2_Schema(@Nullable Aliases.ColumnPath current) {
-    this.alias = current != null ? current.getAlias() : null;
+    $alias = current != null ? current.getAlias() : null;
     this.name = new ColumnDef<Item2, String>(this, "name", String.class, "TEXT", ColumnDef.PRIMARY_KEY) {
       @Override
       @NonNull
@@ -73,7 +73,7 @@ public class Item2_Schema implements Schema<Item2> {
         return model.category2.id;
       }
     };
-    $DEFAULT_RESULT_COLUMNS = new String[]{
+    $defaultResultColumns = new String[]{
           category1.getQualifiedName(),
             category1.associationSchema.name.getQualifiedName(),
             category1.associationSchema.id.getQualifiedName()
@@ -107,13 +107,13 @@ public class Item2_Schema implements Schema<Item2> {
   @Nullable
   @Override
   public String getTableAlias() {
-    return alias;
+    return $alias;
   }
 
   @Nullable
   @Override
   public String getEscapedTableAlias() {
-    return alias != null ? '`' + alias + '`' : null;
+    return $alias != null ? '`' + $alias + '`' : null;
   }
 
   @NonNull
@@ -146,7 +146,7 @@ public class Item2_Schema implements Schema<Item2> {
   @NonNull
   @Override
   public String[] getDefaultResultColumns() {
-    return $DEFAULT_RESULT_COLUMNS;
+    return $defaultResultColumns;
   }
 
   @NonNull

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item_Schema.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item_Schema.java
@@ -18,20 +18,20 @@ public class Item_Schema implements Schema<Item> {
   public static final Item_Schema INSTANCE = Schemas.register(new Item_Schema());
 
   @Nullable
-  public final String alias;
+  private final String $alias;
 
   public final AssociationDef<Item, Category, Category_Schema> category;
 
   public final ColumnDef<Item, String> name;
 
-  private final String[] $DEFAULT_RESULT_COLUMNS;
+  private final String[] $defaultResultColumns;
 
   public Item_Schema() {
     this(new Aliases().createPath("Item"));
   }
 
   public Item_Schema(@Nullable Aliases.ColumnPath current) {
-    this.alias = current != null ? current.getAlias() : null;
+    $alias = current != null ? current.getAlias() : null;
     this.name = new ColumnDef<Item, String>(this, "name", String.class, "TEXT", ColumnDef.PRIMARY_KEY) {
       @Override
       @NonNull
@@ -58,7 +58,7 @@ public class Item_Schema implements Schema<Item> {
         return model.category.id;
       }
     };
-    $DEFAULT_RESULT_COLUMNS = new String[]{
+    $defaultResultColumns = new String[]{
           category.getQualifiedName(),
             category.associationSchema.name.getQualifiedName(),
             category.associationSchema.id.getQualifiedName()
@@ -88,13 +88,13 @@ public class Item_Schema implements Schema<Item> {
   @Nullable
   @Override
   public String getTableAlias() {
-    return alias;
+    return $alias;
   }
 
   @Nullable
   @Override
   public String getEscapedTableAlias() {
-    return alias != null ? '`' + alias + '`' : null;
+    return $alias != null ? '`' + $alias + '`' : null;
   }
 
   @NonNull
@@ -124,7 +124,7 @@ public class Item_Schema implements Schema<Item> {
   @NonNull
   @Override
   public String[] getDefaultResultColumns() {
-    return $DEFAULT_RESULT_COLUMNS;
+    return $defaultResultColumns;
   }
 
   @NonNull

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Schema.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Schema.java
@@ -19,7 +19,7 @@ public class Todo_Schema implements Schema<Todo> {
   public static final Todo_Schema INSTANCE = Schemas.register(new Todo_Schema());
 
   @Nullable
-  public final String alias;
+  private final String $alias;
 
   public final ColumnDef<Todo, String> title;
 
@@ -31,14 +31,14 @@ public class Todo_Schema implements Schema<Todo> {
 
   public final ColumnDef<Todo, Long> id;
 
-  private final String[] $DEFAULT_RESULT_COLUMNS;
+  private final String[] $defaultResultColumns;
 
   public Todo_Schema() {
     this(null);
   }
 
   public Todo_Schema(@Nullable Aliases.ColumnPath current) {
-    this.alias = current != null ? current.getAlias() : null;
+    $alias = current != null ? current.getAlias() : null;
     this.id = new ColumnDef<Todo, Long>(this, "id", long.class, "INTEGER", ColumnDef.PRIMARY_KEY | ColumnDef.AUTO_VALUE) {
       @Override
       @NonNull
@@ -104,7 +104,7 @@ public class Todo_Schema implements Schema<Todo> {
         return BuiltInSerializers.serializeDate(model.createdTime);
       }
     };
-    $DEFAULT_RESULT_COLUMNS = new String[]{
+    $defaultResultColumns = new String[]{
           title.getQualifiedName(),
           content.getQualifiedName(),
           done.getQualifiedName(),
@@ -134,13 +134,13 @@ public class Todo_Schema implements Schema<Todo> {
   @Nullable
   @Override
   public String getTableAlias() {
-    return alias;
+    return $alias;
   }
 
   @Nullable
   @Override
   public String getEscapedTableAlias() {
-    return alias != null ? '`' + alias + '`' : null;
+    return $alias != null ? '`' + $alias + '`' : null;
   }
 
   @NonNull
@@ -170,7 +170,7 @@ public class Todo_Schema implements Schema<Todo> {
   @NonNull
   @Override
   public String[] getDefaultResultColumns() {
-    return $DEFAULT_RESULT_COLUMNS;
+    return $defaultResultColumns;
   }
 
   @NonNull

--- a/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
@@ -164,7 +164,8 @@ public class SchemaTest {
     public void multipleDirectAssociations() throws Exception {
         ModelWithDirectAssociation2_Schema schema = ModelWithDirectAssociation2_Schema.INSTANCE;
 
-        assertThat(schema.alias, is(notNullValue()));
+        assertThat(schema.getTableAlias(), is(notNullValue()));
+        assertThat(schema.getEscapedTableAlias(), is(notNullValue()));
 
         assertThat(schema.note.getQualifiedName(), is("`" + schema.alias + "`.`note`"));
         assertThat(schema.note.orderInAscending().toString(), is(schema.getEscapedTableAlias() + ".`note` ASC"));

--- a/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/SchemaTest.java
@@ -87,6 +87,9 @@ public class SchemaTest {
     public void testAuthorSchema() throws Exception {
         Author_Schema schema = Author_Schema.INSTANCE;
 
+        assertThat(schema.getTableAlias(), is(nullValue()));
+        assertThat(schema.getEscapedTableAlias(), is(nullValue()));
+
         assertThat(schema.getTableName(), is("Author"));
         assertThat(schema.getPrimaryKey(), is((ColumnDef) schema.name));
     }
@@ -167,7 +170,7 @@ public class SchemaTest {
         assertThat(schema.getTableAlias(), is(notNullValue()));
         assertThat(schema.getEscapedTableAlias(), is(notNullValue()));
 
-        assertThat(schema.note.getQualifiedName(), is("`" + schema.alias + "`.`note`"));
+        assertThat(schema.note.getQualifiedName(), is(schema.getEscapedTableAlias() + ".`note`"));
         assertThat(schema.note.orderInAscending().toString(), is(schema.getEscapedTableAlias() + ".`note` ASC"));
         assertThat(schema.note.orderInDescending().toString(), is(schema.getEscapedTableAlias() + ".`note` DESC"));
 
@@ -179,7 +182,8 @@ public class SchemaTest {
     public void nestedDirectAssociations() throws Exception {
         ModelWithNestedDirectAssociations_Schema schema = ModelWithNestedDirectAssociations_Schema.INSTANCE;
 
-        assertThat(schema.alias, is(notNullValue()));
+        assertThat(schema.getTableAlias(), is(notNullValue()));
+        assertThat(schema.getEscapedTableAlias(), is(notNullValue()));
         assertThat(schema.md.associationSchema.name.getQualifiedName(), endsWith(".`name`"));
     }
 }

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/generator/SchemaWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/generator/SchemaWriter.java
@@ -50,7 +50,9 @@ import javax.lang.model.element.VariableElement;
  */
 public class SchemaWriter extends BaseWriter {
 
-    private static final String DEFAULT_RESULT_COLUMNS = "$DEFAULT_RESULT_COLUMNS";
+    private static final String $defaultResultColumns = "$defaultResultColumns";
+
+    private static final String $alias = "$alias";
 
     private static final String onConflictAlgorithm = "onConflictAlgorithm";
 
@@ -102,7 +104,7 @@ public class SchemaWriter extends BaseWriter {
                 .initializer("$T.register(new $T())", Types.Schemas, schema.getSchemaClassName())
                 .build());
 
-        fieldSpecs.add(FieldSpec.builder(Types.String, "alias", publicFinal)
+        fieldSpecs.add(FieldSpec.builder(Types.String, $alias, Modifier.PRIVATE, Modifier.FINAL)
                 .addAnnotation(Annotations.nullable())
                 .build());
 
@@ -127,7 +129,7 @@ public class SchemaWriter extends BaseWriter {
         }
 
         fieldSpecs.add(
-                FieldSpec.builder(Types.StringArray, DEFAULT_RESULT_COLUMNS)
+                FieldSpec.builder(Types.StringArray, $defaultResultColumns)
                         .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                         .build()
         );
@@ -385,10 +387,10 @@ public class SchemaWriter extends BaseWriter {
                         .addParameter(ParameterSpec.builder(Types.ColumnPath, "current")
                                 .addAnnotation(Annotations.nullable())
                                 .build())
-                        .addStatement("this.alias = current != null ? current.getAlias() : null")
+                        .addStatement("$L = current != null ? current.getAlias() : null", $alias)
                         .addCode(buildFieldInitializations())
                         .addStatement("$L = new String[]{\n$L}",
-                                DEFAULT_RESULT_COLUMNS, buildEscapedColumnNamesInitializer(schema, Collections.emptyList()))
+                                $defaultResultColumns, buildEscapedColumnNamesInitializer(schema, Collections.emptyList()))
                         .build()
         );
 
@@ -424,7 +426,7 @@ public class SchemaWriter extends BaseWriter {
                         .addAnnotations(Annotations.overrideAndNullable())
                         .addModifiers(Modifier.PUBLIC)
                         .returns(Types.String)
-                        .addStatement("return alias")
+                        .addStatement("return $L", $alias)
                         .build()
         );
 
@@ -433,7 +435,7 @@ public class SchemaWriter extends BaseWriter {
                         .addAnnotations(Annotations.overrideAndNullable())
                         .addModifiers(Modifier.PUBLIC)
                         .returns(Types.String)
-                        .addStatement("return alias != null ? '`' + alias + '`' : null")
+                        .addStatement("return $L != null ? '`' + $L + '`' : null", $alias, $alias)
                         .build()
         );
 
@@ -469,7 +471,7 @@ public class SchemaWriter extends BaseWriter {
                         .addAnnotations(Annotations.overrideAndNonNull())
                         .addModifiers(Modifier.PUBLIC)
                         .returns(Types.StringArray)
-                        .addStatement("return $L", DEFAULT_RESULT_COLUMNS)
+                        .addStatement("return $L", $defaultResultColumns)
                         .build()
         );
 


### PR DESCRIPTION
Don't use names with `/^[a-zA-Z0-9_]+$/` in `Schema` because they are reserved for column names.