### PR TITLE
respect orderBy terms in Selector#clone()

### DIFF
--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Selector.java
@@ -3,7 +3,6 @@ package com.github.gfx.android.orma.example.orma;
 import android.support.annotation.NonNull;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Selector;
-import com.github.gfx.android.orma.internal.OrmaConditionBase;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -15,9 +14,14 @@ public class Category_Selector extends Selector<Category, Category_Selector> {
     this.schema = schema;
   }
 
-  public Category_Selector(OrmaConditionBase<Category, ?> condition) {
-    super(condition);
-    this.schema = (Category_Schema) condition.getSchema();
+  public Category_Selector(Category_Selector selector) {
+    super(selector);
+    this.schema = selector.getSchema();
+  }
+
+  public Category_Selector(Category_Relation relation) {
+    super(relation);
+    this.schema = relation.getSchema();
   }
 
   @Override

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Selector.java
@@ -3,7 +3,6 @@ package com.github.gfx.android.orma.example.orma;
 import android.support.annotation.NonNull;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Selector;
-import com.github.gfx.android.orma.internal.OrmaConditionBase;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -15,9 +14,14 @@ public class Item2_Selector extends Selector<Item2, Item2_Selector> {
     this.schema = schema;
   }
 
-  public Item2_Selector(OrmaConditionBase<Item2, ?> condition) {
-    super(condition);
-    this.schema = (Item2_Schema) condition.getSchema();
+  public Item2_Selector(Item2_Selector selector) {
+    super(selector);
+    this.schema = selector.getSchema();
+  }
+
+  public Item2_Selector(Item2_Relation relation) {
+    super(relation);
+    this.schema = relation.getSchema();
   }
 
   @Override

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item_Selector.java
@@ -3,7 +3,6 @@ package com.github.gfx.android.orma.example.orma;
 import android.support.annotation.NonNull;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Selector;
-import com.github.gfx.android.orma.internal.OrmaConditionBase;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -15,9 +14,14 @@ public class Item_Selector extends Selector<Item, Item_Selector> {
     this.schema = schema;
   }
 
-  public Item_Selector(OrmaConditionBase<Item, ?> condition) {
-    super(condition);
-    this.schema = (Item_Schema) condition.getSchema();
+  public Item_Selector(Item_Selector selector) {
+    super(selector);
+    this.schema = selector.getSchema();
+  }
+
+  public Item_Selector(Item_Relation relation) {
+    super(relation);
+    this.schema = relation.getSchema();
   }
 
   @Override

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Selector.java
@@ -3,7 +3,6 @@ package com.github.gfx.android.orma.example.orma;
 import android.support.annotation.NonNull;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Selector;
-import com.github.gfx.android.orma.internal.OrmaConditionBase;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -15,9 +14,14 @@ public class Todo_Selector extends Selector<Todo, Todo_Selector> {
     this.schema = schema;
   }
 
-  public Todo_Selector(OrmaConditionBase<Todo, ?> condition) {
-    super(condition);
-    this.schema = (Todo_Schema) condition.getSchema();
+  public Todo_Selector(Todo_Selector selector) {
+    super(selector);
+    this.schema = selector.getSchema();
+  }
+
+  public Todo_Selector(Todo_Relation relation) {
+    super(relation);
+    this.schema = relation.getSchema();
   }
 
   @Override

--- a/library/src/main/java/com/github/gfx/android/orma/Selector.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Selector.java
@@ -71,7 +71,12 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
 
     public Selector(@NonNull Selector<Model, ?> selector) {
         super(selector);
+        groupBy = selector.groupBy;
+        having = selector.having;
         orderBy = selector.orderBy;
+        limit = selector.limit;
+        offset = selector.offset;
+        page = selector.page;
     }
 
     @Override

--- a/library/src/main/java/com/github/gfx/android/orma/Selector.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Selector.java
@@ -63,17 +63,15 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
         super(conn);
     }
 
-    public Selector(@NonNull OrmaConditionBase<Model, ?> condition) {
-        super(condition);
-        if (condition instanceof Relation) {
-            @SuppressWarnings("unchecked")
-            Relation<Model, ?> relation = (Relation<Model, ?>) condition;
-            orderBy = relation.buildOrderingTerms();
-        } else if (condition instanceof Selector) {
-            @SuppressWarnings("unchecked")
-            Selector<Model, ?> selector = (Selector<Model, ?>) condition;
-            orderBy = selector.orderBy;
-        }
+    public Selector(@NonNull Relation<Model, ?> relation) {
+        super(relation);
+        orderBy = relation.buildOrderingTerms();
+    }
+
+
+    public Selector(@NonNull Selector<Model, ?> selector) {
+        super(selector);
+        orderBy = selector.orderBy;
     }
 
     @Override

--- a/library/src/main/java/com/github/gfx/android/orma/Selector.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Selector.java
@@ -68,10 +68,11 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
         if (condition instanceof Relation) {
             @SuppressWarnings("unchecked")
             Relation<Model, ?> relation = (Relation<Model, ?>) condition;
-            CharSequence orderByTerm = relation.buildOrderingTerms();
-            if (orderByTerm != null) {
-                orderBy(orderByTerm);
-            }
+            orderBy = relation.buildOrderingTerms();
+        } else if (condition instanceof Selector) {
+            @SuppressWarnings("unchecked")
+            Selector<Model, ?> selector = (Selector<Model, ?>) condition;
+            orderBy = selector.orderBy;
         }
     }
 

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
@@ -148,18 +148,30 @@ public class QueryTest {
 
     @Test
     public void iterable() throws Exception {
-        List<Book> books = new ArrayList<>();
+        {
+            List<Book> books = new ArrayList<>();
 
-        for (Book book : db.selectFromBook()) {
-            books.add(book);
+            for (Book book : db.selectFromBook().orderByTitleAsc()) {
+                books.add(book);
+            }
+
+            assertThat(books, hasSize(2));
+
+            assertThat(books.get(0).title, is("friday"));
+            assertThat(books.get(1).title, is("today"));
         }
+        {
+            List<Book> books = new ArrayList<>();
 
-        assertThat(books, hasSize(2));
-        assertThat(books.get(0).title, is("today"));
-        assertThat(books.get(0).content, is("milk, banana"));
+            for (Book book : db.selectFromBook().orderByTitleDesc()) {
+                books.add(book);
+            }
 
-        assertThat(books.get(1).title, is("friday"));
-        assertThat(books.get(1).content, is("apple"));
+            assertThat(books, hasSize(2));
+
+            assertThat(books.get(0).title, is("today"));
+            assertThat(books.get(1).title, is("friday"));
+        }
     }
 
     @Test

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/generator/SelectorWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/generator/SelectorWriter.java
@@ -80,9 +80,16 @@ public class SelectorWriter extends BaseWriter {
 
         methodSpecs.add(MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(Types.getOrmaConditionBase(schema.getModelClassName()), "condition")
-                .addStatement("super(condition)")
-                .addStatement("this.schema = ($T) condition.getSchema()", schema.getSchemaClassName())
+                .addParameter(schema.getSelectorClassName(), "selector")
+                .addStatement("super(selector)")
+                .addStatement("this.schema = selector.getSchema()", schema.getSchemaClassName())
+                .build());
+
+        methodSpecs.add(MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(schema.getRelationClassName(), "relation")
+                .addStatement("super(relation)")
+                .addStatement("this.schema = relation.getSchema()", schema.getSchemaClassName())
                 .build());
 
         methodSpecs.add(MethodSpec.methodBuilder("clone")


### PR DESCRIPTION
Fix a problem that `Selector#orderBy` is ignored in `Selector#clone` and `new Selector(selector)`.

cc: @sys1yagi