### PR TITLE
Support generic type adapters

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
+++ b/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
@@ -169,6 +169,15 @@ public class BuiltInSerializers {
         return writer.toString();
     }
 
+    @SuppressWarnings("unchecked")
+    private static <C extends Collection<String>> C createCollection(Class<?> collectionClass) {
+        try {
+            return (C)collectionClass.newInstance();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
     /**
      * A generic deserializer for string collections.
      *
@@ -177,17 +186,10 @@ public class BuiltInSerializers {
      * @param <C>             A concrete collection class, e.g. {@code ArrayList<String>}.
      * @return A collection instance retrieved from {@code serialized}.
      */
-    @SuppressWarnings("unchecked")
     @NonNull
     public static <C extends Collection<String>> C deserializeStringCollection(@NonNull String serialized,
             @NonNull Class<?> collectionClass) {
-        C collection;
-
-        try {
-            collection = (C)collectionClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new AssertionError(e);
-        }
+        C collection = createCollection(collectionClass);
 
         StringReader reader = new StringReader(serialized);
         JsonReader jsonReader = new JsonReader(reader);
@@ -218,7 +220,7 @@ public class BuiltInSerializers {
     @SuppressWarnings("unchecked")
     @NonNull
     public static List<String> deserializeStringList(@NonNull String serialized) {
-        return BuiltInSerializers.deserializeStringCollection(serialized, ArrayList.class);
+        return deserializeStringCollection(serialized, ArrayList.class);
     }
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
+++ b/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
@@ -177,13 +177,14 @@ public class BuiltInSerializers {
      * @param <C>             A concrete collection class, e.g. {@code ArrayList<String>}.
      * @return A collection instance retrieved from {@code serialized}.
      */
+    @SuppressWarnings("unchecked")
     @NonNull
     public static <C extends Collection<String>> C deserializeStringCollection(@NonNull String serialized,
-            @NonNull Class<C> collectionClass) {
+            @NonNull Class<?> collectionClass) {
         C collection;
 
         try {
-            collection = collectionClass.newInstance();
+            collection = (C)collectionClass.newInstance();
         } catch (InstantiationException | IllegalAccessException e) {
             throw new AssertionError(e);
         }
@@ -217,7 +218,7 @@ public class BuiltInSerializers {
     @SuppressWarnings("unchecked")
     @NonNull
     public static List<String> deserializeStringList(@NonNull String serialized) {
-        return deserializeStringCollection(serialized, ArrayList.class);
+        return BuiltInSerializers.deserializeStringCollection(serialized, ArrayList.class);
     }
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
+++ b/library/src/main/java/com/github/gfx/android/orma/BuiltInSerializers.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Currency;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -146,6 +145,13 @@ public class BuiltInSerializers {
 
     // collections
 
+    /**
+     * A generic serializer for string collections.
+     *
+     * @param collection Collection to serialize
+     * @param <C>        A concrete collection class, e.g. {@code ArrayList<String>}.
+     * @return JSON representation of the string collection.
+     */
     @NonNull
     public static <C extends Collection<String>> String serializeStringCollection(@NonNull C collection) {
         StringWriter writer = new StringWriter();
@@ -163,8 +169,25 @@ public class BuiltInSerializers {
         return writer.toString();
     }
 
+    /**
+     * A generic deserializer for string collections.
+     *
+     * @param serialized      JSON representation of a string collection.
+     * @param collectionClass Concrete, instantiatable collection class, e.g. {@code ArrayList.class}.
+     * @param <C>             A concrete collection class, e.g. {@code ArrayList<String>}.
+     * @return A collection instance retrieved from {@code serialized}.
+     */
     @NonNull
-    public static <C extends Collection<String>> C deserializeStringCollection(@NonNull String serialized, @NonNull C collection) {
+    public static <C extends Collection<String>> C deserializeStringCollection(@NonNull String serialized,
+            @NonNull Class<C> collectionClass) {
+        C collection;
+
+        try {
+            collection = collectionClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+
         StringReader reader = new StringReader(serialized);
         JsonReader jsonReader = new JsonReader(reader);
 
@@ -191,19 +214,10 @@ public class BuiltInSerializers {
         return serializeStringCollection(source);
     }
 
+    @SuppressWarnings("unchecked")
     @NonNull
     public static List<String> deserializeStringList(@NonNull String serialized) {
-        return deserializeStringCollection(serialized, new ArrayList<String>());
-    }
-
-    @NonNull
-    public static String serializeStringArrayList(@NonNull ArrayList<String> source) {
-        return serializeStringCollection(source);
-    }
-
-    @NonNull
-    public static ArrayList<String> deserializeStringArrayList(@NonNull String serialized) {
-        return deserializeStringCollection(serialized, new ArrayList<String>());
+        return deserializeStringCollection(serialized, ArrayList.class);
     }
 
     @NonNull
@@ -211,18 +225,9 @@ public class BuiltInSerializers {
         return serializeStringCollection(source);
     }
 
+    @SuppressWarnings("unchecked")
     @NonNull
     public static Set<String> deserializeStringSet(@NonNull String serialized) {
-        return deserializeStringCollection(serialized, new LinkedHashSet<String>());
-    }
-
-    @NonNull
-    public static String serializeStringHashSet(@NonNull HashSet<String> source) {
-        return serializeStringCollection(source);
-    }
-
-    @NonNull
-    public static HashSet<String> deserializeStringHashSet(@NonNull String serialized) {
-        return deserializeStringCollection(serialized, new HashSet<String>());
+        return deserializeStringCollection(serialized, HashSet.class);
     }
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/ModelSpecTest.java
@@ -27,6 +27,8 @@ import com.github.gfx.android.orma.test.model.ModelWithPrimitives;
 import com.github.gfx.android.orma.test.model.ModelWithTypeAdapters;
 import com.github.gfx.android.orma.test.model.OrmaDatabase;
 import com.github.gfx.android.orma.test.model.OrmaDatabaseToAvoidTryParsing;
+import com.github.gfx.android.orma.test.toolbox.EnumA;
+import com.github.gfx.android.orma.test.toolbox.EnumB;
 import com.github.gfx.android.orma.test.toolbox.IntTuple2;
 import com.github.gfx.android.orma.test.toolbox.MutableInt;
 import com.github.gfx.android.orma.test.toolbox.MutableLong;
@@ -168,6 +170,8 @@ public class ModelSpecTest {
                 model.mutableInt = new MutableInt(42);
                 model.mutableLong = new MutableLong(43);
                 model.byteBuffer = ByteBuffer.wrap(new byte[]{0, 1, 2, 3});
+                model.enumA = EnumA.FOO;
+                model.enumB = EnumB.BAR;
                 return model;
             }
         });
@@ -189,6 +193,8 @@ public class ModelSpecTest {
         assertThat(model.mutableInt.value, is(42));
         assertThat(model.mutableLong.value, is(43L));
         assertThat(model.byteBuffer, is(ByteBuffer.wrap(new byte[]{0, 1, 2, 3})));
+        assertThat(model.enumA, is(EnumA.FOO));
+        assertThat(model.enumB, is(EnumB.BAR));
 
         // nullable
         assertThat(model.nullableUri, is(nullValue())); // TEXT
@@ -226,6 +232,8 @@ public class ModelSpecTest {
                 model.mutableInt = new MutableInt(42);
                 model.mutableLong = new MutableLong(43);
                 model.byteBuffer = ByteBuffer.wrap(new byte[]{0, 1, 2, 3});
+                model.enumA = EnumA.FOO;
+                model.enumB = EnumB.BAR;
                 return model;
             }
         });

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.Currency;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -102,6 +104,14 @@ public class ModelWithTypeAdapters {
     @Nullable
     @Column(indexed = true)
     public Set<String> nullableSet;
+
+    @Nullable
+    @Column(indexed = true)
+    public LinkedList<String> nullableLinkedList;
+
+    @Nullable
+    @Column(indexed = true)
+    public LinkedHashSet<String> nullableLinkedHashSet;
 
     @Nullable
     @Column(indexed = true)

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithTypeAdapters.java
@@ -18,6 +18,8 @@ package com.github.gfx.android.orma.test.model;
 import com.github.gfx.android.orma.annotation.Column;
 import com.github.gfx.android.orma.annotation.PrimaryKey;
 import com.github.gfx.android.orma.annotation.Table;
+import com.github.gfx.android.orma.test.toolbox.EnumA;
+import com.github.gfx.android.orma.test.toolbox.EnumB;
 import com.github.gfx.android.orma.test.toolbox.IntTuple2;
 import com.github.gfx.android.orma.test.toolbox.MutableInt;
 import com.github.gfx.android.orma.test.toolbox.MutableLong;
@@ -116,4 +118,10 @@ public class ModelWithTypeAdapters {
     @Column(indexed = true)
     @Nullable
     public ByteBuffer nullableByteBuffer;
+
+    @Column(indexed = true)
+    public EnumA enumA;
+
+    @Column(indexed = true)
+    public EnumB enumB;
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/toolbox/EnumA.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/toolbox/EnumA.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.toolbox;
+
+public enum EnumA implements EnumDescription {
+    FOO
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/toolbox/EnumB.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/toolbox/EnumB.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.toolbox;
+
+public enum EnumB implements EnumDescription {
+    BAR
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/toolbox/EnumDescription.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/toolbox/EnumDescription.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.toolbox;
+
+public interface EnumDescription {
+
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
@@ -27,16 +27,10 @@ import android.support.annotation.NonNull;
 /**
  * An example for generic type adapters; its {@code deserialize ()} methods takes a {@code Class<T> type} parameter.
  */
-@StaticTypeAdapters({
-        @StaticTypeAdapter(
-                targetType = EnumA.class,
-                serializedType = String.class
-        ),
-        @StaticTypeAdapter(
-                targetType = EnumB.class,
-                serializedType = String.class
-        ),
-})
+@StaticTypeAdapter(
+        targetType = EnumDescription.class,
+        serializedType = String.class
+)
 public class EnumTypeAdapter {
 
     public static <T extends Enum<T> & EnumDescription> String serialize(@NonNull T value) {

--- a/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
@@ -39,7 +39,7 @@ import android.support.annotation.NonNull;
 })
 public class EnumTypeAdapter {
 
-    public static <T extends Enum & EnumDescription> String serialize(@NonNull T value) {
+    public static <T extends Enum<T> & EnumDescription> String serialize(@NonNull T value) {
         return value.name();
     }
 

--- a/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.type_adapter;
+
+import com.github.gfx.android.orma.annotation.StaticTypeAdapter;
+import com.github.gfx.android.orma.annotation.StaticTypeAdapters;
+import com.github.gfx.android.orma.test.toolbox.EnumA;
+import com.github.gfx.android.orma.test.toolbox.EnumB;
+import com.github.gfx.android.orma.test.toolbox.EnumDescription;
+
+import android.support.annotation.NonNull;
+
+@StaticTypeAdapters({
+        @StaticTypeAdapter(
+                targetType = EnumA.class,
+                serializedType = String.class
+        ),
+        @StaticTypeAdapter(
+                targetType = EnumB.class,
+                serializedType = String.class
+        ),
+})
+public class EnumTypeAdapter {
+
+    public static <T extends Enum & EnumDescription> String serialize(@NonNull T value) {
+        return value.name();
+    }
+
+    @SuppressWarnings("unchecked")
+    @NonNull
+    public static <T extends Enum<T> & EnumDescription> T deserialize(@NonNull Class<T> type, @NonNull String serialized) {
+        return Enum.valueOf(type, serialized);
+    }
+}

--- a/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
@@ -24,6 +24,9 @@ import com.github.gfx.android.orma.test.toolbox.EnumDescription;
 
 import android.support.annotation.NonNull;
 
+/**
+ * An example for generic type adapters; its {@code deserialize ()} methods takes a {@code Class<T> type} parameter.
+ */
 @StaticTypeAdapters({
         @StaticTypeAdapter(
                 targetType = EnumA.class,
@@ -42,7 +45,7 @@ public class EnumTypeAdapter {
 
     @SuppressWarnings("unchecked")
     @NonNull
-    public static <T extends Enum<T> & EnumDescription> T deserialize(@NonNull Class<T> type, @NonNull String serialized) {
+    public static <T extends Enum<T> & EnumDescription> T deserialize(@NonNull String serialized, @NonNull Class<T> type) {
         return Enum.valueOf(type, serialized);
     }
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/type_adapter/EnumTypeAdapter.java
@@ -17,9 +17,6 @@
 package com.github.gfx.android.orma.test.type_adapter;
 
 import com.github.gfx.android.orma.annotation.StaticTypeAdapter;
-import com.github.gfx.android.orma.annotation.StaticTypeAdapters;
-import com.github.gfx.android.orma.test.toolbox.EnumA;
-import com.github.gfx.android.orma.test.toolbox.EnumB;
 import com.github.gfx.android.orma.test.toolbox.EnumDescription;
 
 import android.support.annotation.NonNull;

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/generator/SchemaWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/generator/SchemaWriter.java
@@ -722,7 +722,7 @@ public class SchemaWriter extends BaseWriter {
             TypeName type = c.getUnboxType();
 
             CodeBlock index = CodeBlock.of("offset + $L", i + offset);
-            builder.addStatement("$L$L", lhsBaseGen.apply(c),  c.buildSetColumnExpr(buildGetValueFromCursor(c, index)));
+            builder.addStatement("$L$L", lhsBaseGen.apply(c), c.buildSetColumnExpr(buildGetValueFromCursor(c, index)));
 
             if (Types.isDirectAssociation(context, type)) {
                 SchemaDefinition associatedSchema = c.getAssociatedSchema();

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/model/ColumnDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/model/ColumnDefinition.java
@@ -107,7 +107,7 @@ public class ColumnDefinition {
         columnName = columnName(column, element);
 
         type = ClassName.get(element.asType());
-        typeAdapter = schema.context.typeAdapterMap.get(type);
+        typeAdapter = schema.context.findTypeAdapter(element.asType());
 
         storageType = (column != null && !Strings.isEmpty(column.storageType())) ? column.storageType() : null;
 
@@ -167,7 +167,7 @@ public class ColumnDefinition {
         onDeleteAction = Column.ForeignKeyAction.NO_ACTION;
         onUpdateAction = Column.ForeignKeyAction.NO_ACTION;
         helperFlags = normalizeHelperFlags(primaryKey, indexed, autoincrement, autoId, Column.Helpers.AUTO);
-        typeAdapter = schema.context.typeAdapterMap.get(type);
+        typeAdapter = schema.context.getTypeAdapter(type);
         storageType = null;
     }
 
@@ -370,8 +370,8 @@ public class ColumnDefinition {
             } else {
                 // inject Class<T> if the deserializer takes more than one
                 TypeName rawType = (type instanceof ParameterizedTypeName ? ((ParameterizedTypeName) type).rawType : type);
-                return CodeBlock.of("$T.$L($L, $T.class)",
-                        typeAdapter.typeAdapterImpl, typeAdapter.getDeserializerName(), valueExpr, rawType);
+                return CodeBlock.of("$T.<$T>$L($L, $T.class)",
+                        typeAdapter.typeAdapterImpl, type, typeAdapter.getDeserializerName(), valueExpr, rawType);
             }
 
         } else {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/model/ColumnDefinition.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/model/ColumnDefinition.java
@@ -367,19 +367,19 @@ public class ColumnDefinition {
     }
 
     public CodeBlock buildDeserializeExpr(CodeBlock valueExpr) {
-        // TODO: parameter injection for static type serializers
         if (needsTypeAdapter()) {
             if (typeAdapter == null) {
                 throw new ProcessingException("Missing @StaticTypeAdapter to deserialize " + type, element);
             }
 
-            if (typeAdapter.deserializerMethod == null || typeAdapter.deserializerMethod.getParameters().size() == 1) {
+            if (!typeAdapter.generic) {
                 return CodeBlock.of("$T.$L($L)",
                         typeAdapter.typeAdapterImpl, typeAdapter.getDeserializerName(), valueExpr);
             } else {
                 // inject Class<T> if the deserializer takes more than one
-                return CodeBlock.of("$T.$L($T.class, $L)",
-                        typeAdapter.typeAdapterImpl, typeAdapter.getDeserializerName(), type, valueExpr);
+                TypeName rawType = (type instanceof ParameterizedTypeName ? ((ParameterizedTypeName) type).rawType : type);
+                return CodeBlock.of("$T.$L($L, $T.class)",
+                        typeAdapter.typeAdapterImpl, typeAdapter.getDeserializerName(), valueExpr, rawType);
             }
 
         } else {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/util/SqlTypes.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/util/SqlTypes.java
@@ -50,6 +50,10 @@ public class SqlTypes {
         // TODO: date and time types?
     }
 
+    public static boolean canHandle(TypeName type) {
+        return javaToSqlite.containsKey(type);
+    }
+
     public static String getSqliteType(TypeName type) {
         String t = javaToSqlite.get(Types.asUnboxType(type));
         return t != null ? t : "BLOB";

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/util/Types.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/util/Types.java
@@ -28,11 +28,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class Types {
 
@@ -289,5 +290,13 @@ public class Types {
 
     public static boolean isNumeric(TypeName type) {
         return numericTypes.contains(type);
+    }
+
+    public static ParameterizedTypeName getLinkedList(TypeName type) {
+        return ParameterizedTypeName.get(ClassName.get(LinkedList.class), type);
+    }
+
+    public static ParameterizedTypeName getLinkedHashSet(TypeName type) {
+        return ParameterizedTypeName.get(ClassName.get(LinkedHashSet.class), type);
     }
 }


### PR DESCRIPTION
Given an interface `EnumDescription` and enum `EnumA` and `EnumB` which implement `EnumDescription`, type adapter for `EnumDescription` can handle its descendants, `EnumA` and `EnumB`:

```java
@StaticTypeAdapter(
        targetType = EnumDescription.class,
        serializedType = String.class
)
public class EnumTypeAdapter {

    public static <T extends Enum<T> & EnumDescription> String serialize(@NonNull T value) {
        return value.name();
    }

    @SuppressWarnings("unchecked")
    @NonNull
    public static <T extends Enum<T> & EnumDescription> T deserialize(@NonNull String serialized, @NonNull Class<T> type) {
        return Enum.valueOf(type, serialized);
    }
}
```