### PR TITLE
Allows square brackets to escape identifiers

### DIFF
--- a/migration/src/main/java/com/github/gfx/android/orma/migration/SqliteDdlBuilder.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/SqliteDdlBuilder.java
@@ -34,9 +34,9 @@ public class SqliteDdlBuilder {
 
     @NonNull
     public static String ensureNotEscaped(@NonNull String maybeEscaped) {
-        if (maybeEscaped.startsWith("\"") || maybeEscaped.endsWith("\n")) {
-            return maybeEscaped.substring(1, maybeEscaped.length() - 1);
-        } else if (maybeEscaped.startsWith("`") || maybeEscaped.endsWith("`")) {
+        if ((maybeEscaped.startsWith("\"") && maybeEscaped.endsWith("\""))
+                || (maybeEscaped.startsWith("`") && maybeEscaped.endsWith("`"))
+                || (maybeEscaped.startsWith("[") && maybeEscaped.endsWith("]"))) {
             return maybeEscaped.substring(1, maybeEscaped.length() - 1);
         } else {
             return maybeEscaped;
@@ -44,7 +44,8 @@ public class SqliteDdlBuilder {
     }
 
     @NonNull
-    public String buildCreateTable(@NonNull SQLiteComponent.Name table, @NonNull List<CreateTableStatement.ColumnDef> columns) {
+    public String buildCreateTable(@NonNull SQLiteComponent.Name table,
+            @NonNull List<CreateTableStatement.ColumnDef> columns) {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE TABLE ");
         sb.append(table);

--- a/migration/src/test/java/com/github/gfx/android/orma/migration/test/TableDiffTest.java
+++ b/migration/src/test/java/com/github/gfx/android/orma/migration/test/TableDiffTest.java
@@ -71,12 +71,29 @@ public class TableDiffTest {
     }
 
     @Test
+    public void sameButRemoveBrackets() throws Exception {
+        String a = "CREATE TABLE [todo] ([title] TEXT, [content] TEXT)";
+        String b = "CREATE TABLE todo (title TEXT, content TEXT)";
+        List<String> statements = migration.tableDiff(a, b);
+        assertThat(statements, is(empty()));
+    }
+
+    @Test
+    public void sameButAddBrackets() throws Exception {
+        String a = "CREATE TABLE todo (title TEXT, content TEXT)";
+        String b = "CREATE TABLE [todo] ([title] TEXT, [content] TEXT)";
+        List<String> statements = migration.tableDiff(a, b);
+        assertThat(statements, is(empty()));
+    }
+
+    @Test
     public void sameButRemoveQuotes() throws Exception {
         String a = "CREATE TABLE `todo` (`title` TEXT, `content` TEXT)";
         String b = "CREATE TABLE todo (title TEXT, content TEXT)";
         List<String> statements = migration.tableDiff(a, b);
         assertThat(statements, is(empty()));
     }
+
 
     @Test
     public void reorder() throws Exception {


### PR DESCRIPTION
Resolve  #326.

ref. https://www.sqlite.org/lang_keywords.html 

> **[keyword]**		A keyword enclosed in square brackets is an identifier. This is not standard SQL. This quoting mechanism is used by MS Access and SQL Server and is included in SQLite for compatibility.