### PR TITLE
SQLBrite-like query observables

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,47 @@ OrmaDatabase orma = OrmaDatabase.builder(this)
 
 See [migration/README.md](migration/README.md) for details.
 
+## DataSet Changed Events
+
+NOTE: **This is experimental in v4.0.0: its existence, signature or behavior might change without warning from one release to the next.**
+
+There is a way to create [SQLBrite](https://github.com/square/sqlbrite)-like "Query Observable", which observes data-set changed events for tables.
+
+```java
+// NOTE: Keep the observable instance. If it's released, the observable is disposed.
+
+// create a query observable, which is a hot observable
+Observable<Author_Selector> observable = db.relationOfAuthor()
+        .createQueryObservable();
+
+// subscribe the events
+observable.flatMap(new Function<Author_Selector, Observable<Author>>() {
+    @Override
+    public Observable<Author> apply(Author_Selector selector) throws Exception {
+        Log.d(TAG, "Author has been changed!");
+        return selector.executeAsObservable();
+    }
+})
+        .map(new Function<Author, String>() {
+            @Override
+            public String apply(Author author) throws Exception {
+                return author.name;
+            }
+        })
+        .subscribe(new Consumer<String>() {
+            @Override
+            public void accept(String name) throws Exception {
+                Log.d(TAG, "name: " + name);
+            }
+        });
+```
+
+See `OrmaListAdapter` and `OrmaRecyclerViewAdapter`, which use Query Observables to
+trigger `#notifyDataSetChanged()`.
+
+* [OrmaListAdapter](https://github.com/gfx/Android-Orma/blob/master/library/src/main/java/com/github/gfx/android/orma/widget/OrmaListAdapter.java)
+* [OrmaRecyclerViewAdapter](https://github.com/gfx/Android-Orma/blob/master/library/src/main/java/com/github/gfx/android/orma/widget/OrmaRecyclerViewAdapter.java)
+
 ## Cooperation with Serialization Libraries
 
 Beause Orma reuqires nothing to do to models, serializers, e.g. Android Parcels or GSON, can

--- a/annotations/src/main/java/com/github/gfx/android/orma/annotation/Experimental.java
+++ b/annotations/src/main/java/com/github/gfx/android/orma/annotation/Experimental.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.annotation;
+
+import android.support.annotation.RestrictTo;
+
+/**
+ * Indicates the feature is in experimental state: its existence, signature or behavior
+ * might change without warning from one release to the next.
+ */
+@RestrictTo(RestrictTo.Scope.GROUP_ID) // not intended to be used outside the library
+public @interface Experimental {
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ final ANDROID_SDK_PATH = {
 final ANDROID_SUPPORT_REPOSITORY = "${ANDROID_SDK_PATH}/extras/android/m2repository"
 
 ext {
-    SUPPORT_LIBRARY_VERSION = '25.0.0'
+    SUPPORT_LIBRARY_VERSION = '25.0.1'
     ANDROID_JAR = fileTree(dir: "${ANDROID_SDK_PATH}/platforms/android-25/", include: 'android.jar')
 
     versionFile = project.file("VERSION")

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -79,7 +79,5 @@ dependencies {
     compile "com.android.support:recyclerview-v7:${SUPPORT_LIBRARY_VERSION}"
     compile "com.android.support:design:${SUPPORT_LIBRARY_VERSION}"
     compile 'com.jakewharton.threetenabp:threetenabp:1.0.4'
-    compile 'io.reactivex.rxjava2:rxjava:2.0.0'
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.0'
     compile 'com.facebook.stetho:stetho:1.4.1'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     compile "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
     compile 'io.reactivex.rxjava2:rxjava:2.0.0'
+    compile 'io.reactivex.rxjava2:rxandroid:2.0.0'
 
     provided("com.android.support:recyclerview-v7:${SUPPORT_LIBRARY_VERSION}") {
         exclude group: 'com.android.support', module: 'support-v4'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile project(':annotations')
 
     compile "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
-    compile 'io.reactivex.rxjava2:rxjava:2.0.0'
+    compile 'io.reactivex.rxjava2:rxjava:2.0.1'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.0'
 
     provided("com.android.support:recyclerview-v7:${SUPPORT_LIBRARY_VERSION}") {

--- a/library/src/main/java/com/github/gfx/android/orma/Inserter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Inserter.java
@@ -16,6 +16,7 @@
 package com.github.gfx.android.orma;
 
 import com.github.gfx.android.orma.annotation.OnConflict;
+import com.github.gfx.android.orma.event.DataSetChangedEvent;
 import com.github.gfx.android.orma.exception.InsertionFailureException;
 
 import android.database.sqlite.SQLiteDatabase;
@@ -23,6 +24,7 @@ import android.database.sqlite.SQLiteStatement;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
+import java.io.Closeable;
 import java.util.concurrent.Callable;
 
 import io.reactivex.Observable;
@@ -33,7 +35,7 @@ import io.reactivex.Single;
 /**
  * Represents a prepared statement to insert models in batch.
  */
-public class Inserter<Model> {
+public class Inserter<Model> implements Closeable {
 
     final OrmaConnection conn;
 
@@ -71,7 +73,7 @@ public class Inserter<Model> {
         }
         schema.bindArgs(conn, statement, model, withoutAutoId);
         long rowId = statement.executeInsert();
-        conn.trigger(schema);
+        conn.trigger(DataSetChangedEvent.Type.INSERT, schema);
         return rowId;
     }
 
@@ -145,5 +147,10 @@ public class Inserter<Model> {
                 emitter.onComplete();
             }
         });
+    }
+
+    @Override
+    public void close() {
+        statement.close();
     }
 }

--- a/library/src/main/java/com/github/gfx/android/orma/Inserter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Inserter.java
@@ -70,7 +70,9 @@ public class Inserter<Model> {
             conn.trace(sql, schema.convertToArgs(conn, model, withoutAutoId));
         }
         schema.bindArgs(conn, statement, model, withoutAutoId);
-        return statement.executeInsert();
+        long rowId = statement.executeInsert();
+        conn.trigger(schema);
+        return rowId;
     }
 
     /**

--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
@@ -15,6 +15,7 @@
  */
 package com.github.gfx.android.orma;
 
+import com.github.gfx.android.orma.annotation.Experimental;
 import com.github.gfx.android.orma.event.DataSetChangedEvent;
 import com.github.gfx.android.orma.event.DataSetChangedTrigger;
 import com.github.gfx.android.orma.exception.DatabaseAccessOnMainThreadException;
@@ -328,7 +329,8 @@ public class OrmaConnection {
         });
     }
 
-    public <S extends Selector<?, ?>> Observable<DataSetChangedEvent<S>> createQueryObservable(S selector) {
+    @Experimental
+    public <S extends Selector<?, ?>> Observable<DataSetChangedEvent<S>> createEventObservable(S selector) {
         PublishSubject<DataSetChangedEvent<S>> subject = PublishSubject.create();
         trigger.register(subject, selector);
         return subject;

--- a/library/src/main/java/com/github/gfx/android/orma/Relation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Relation.java
@@ -17,6 +17,7 @@ package com.github.gfx.android.orma;
 
 import com.github.gfx.android.orma.annotation.OnConflict;
 import com.github.gfx.android.orma.annotation.PrimaryKey;
+import com.github.gfx.android.orma.event.DataSetChangedEvent;
 import com.github.gfx.android.orma.internal.OrmaConditionBase;
 
 import android.support.annotation.CheckResult;
@@ -254,8 +255,8 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
     }
 
     @SuppressWarnings("unchecked")
-    public Observable<R> createQueryObservable() {
-        return (Observable<R>)conn.createQueryObservable(this);
+    public <S extends Selector<Model, ?>> Observable<DataSetChangedEvent<S>> createQueryObservable() {
+        return conn.createQueryObservable((S)selector());
     }
 
     // Iterator<Model>

--- a/library/src/main/java/com/github/gfx/android/orma/Relation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Relation.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeOnSubscribe;
+import io.reactivex.Observable;
 import io.reactivex.Single;
 
 /**
@@ -250,6 +251,11 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
     @NonNull
     public Inserter<Model> upserter() {
         return inserter(OnConflict.REPLACE, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Observable<R> createQueryObservable() {
+        return (Observable<R>)conn.createQueryObservable(this);
     }
 
     // Iterator<Model>

--- a/library/src/main/java/com/github/gfx/android/orma/Relation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Relation.java
@@ -15,6 +15,7 @@
  */
 package com.github.gfx.android.orma;
 
+import com.github.gfx.android.orma.annotation.Experimental;
 import com.github.gfx.android.orma.annotation.OnConflict;
 import com.github.gfx.android.orma.annotation.PrimaryKey;
 import com.github.gfx.android.orma.event.DataSetChangedEvent;
@@ -35,6 +36,7 @@ import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeOnSubscribe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
+import io.reactivex.functions.Function;
 
 /**
  * Representation of a relation, or a {@code SELECT} query.
@@ -254,9 +256,36 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
         return inserter(OnConflict.REPLACE, false);
     }
 
+    /**
+     * Experimental API to observe data-set changed events.
+     *
+     * @param <S> A concrete {@link Selector} class.
+     * @return A hot observable that yields {@link Selector} when the target data-set is changed.
+     */
+    @Experimental
     @SuppressWarnings("unchecked")
-    public <S extends Selector<Model, ?>> Observable<DataSetChangedEvent<S>> createQueryObservable() {
-        return conn.createQueryObservable((S)selector());
+    public <S extends Selector<Model, ?>> Observable<S> createQueryObservable() {
+        return conn.createEventObservable((S)selector())
+                .map(new Function<DataSetChangedEvent<S>, S>() {
+                    @Override
+                    public S apply(DataSetChangedEvent<S> event) throws Exception {
+                        return event.getSelector();
+                    }
+                });
+    }
+
+    /**
+     * Experimental API to observe data-set changed events.
+     * This is provided to test whether it is useful or not, and not intended to be used in production yet.
+     *
+     * @param <S> A concrete {@link Selector} class.
+     * @return A hot observable that yields {@link Selector} when the target data-set is changed.
+     */
+    @Experimental
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public <S extends Selector<Model, ?>> Observable<DataSetChangedEvent<S>> createEventObservable() {
+        return conn.createEventObservable((S)selector());
     }
 
     // Iterator<Model>

--- a/library/src/main/java/com/github/gfx/android/orma/event/DataSetChangedEvent.java
+++ b/library/src/main/java/com/github/gfx/android/orma/event/DataSetChangedEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.event;
+
+import com.github.gfx.android.orma.Selector;
+
+public class DataSetChangedEvent<S extends Selector<?, ?>> {
+    public enum Type {
+        INSERT,
+        UPDATE,
+        DELETE,
+        TRANSACTION,
+    }
+
+    private final Type type;
+
+    private final S selector;
+
+    public DataSetChangedEvent(Type type, S selector) {
+        this.type = type;
+        this.selector = selector;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public S getSelector() {
+        return selector;
+    }
+}

--- a/library/src/main/java/com/github/gfx/android/orma/event/DataSetChangedTrigger.java
+++ b/library/src/main/java/com/github/gfx/android/orma/event/DataSetChangedTrigger.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.event;
+
+import com.github.gfx.android.orma.Schema;
+import com.github.gfx.android.orma.Selector;
+
+import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.RestrictTo;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import io.reactivex.Observer;
+
+/**
+ * Helper class for query observables. This class is NOT thread-safe.
+ */
+@RestrictTo(RestrictTo.Scope.GROUP_ID)
+public class DataSetChangedTrigger {
+
+    final WeakHashMap<Observer<DataSetChangedEvent<?>>, Selector<?, ?>> observerMap = new WeakHashMap<>();
+
+    Set<Schema<?>> changedDataSetInTransaction = null;
+
+    @SuppressWarnings("unchecked")
+    public <S extends Selector<?, ?>> void register(Observer<DataSetChangedEvent<S>> observer, Selector<?, ?> selector) {
+        observerMap.put((Observer<DataSetChangedEvent<?>>)(Object)observer, selector);
+    }
+
+    public <Model> void fire(SQLiteDatabase db, DataSetChangedEvent.Type type, Schema<Model> schema) {
+        if (observerMap.isEmpty()) {
+            return;
+        }
+        if (db.inTransaction()) {
+            addChangedDataSetInTransaction(schema);
+            return;
+        }
+
+        for (Map.Entry<Observer<DataSetChangedEvent<?>>, Selector<?, ?>> entry : observerMap.entrySet()) {
+            Selector<?, ?> selector = entry.getValue();
+            if (schema == selector.getSchema()) {
+                Observer<DataSetChangedEvent<?>> observer = entry.getKey();
+                observer.onNext(new DataSetChangedEvent<>(type, selector));
+            }
+        }
+    }
+
+    private void addChangedDataSetInTransaction(Schema<?> schema) {
+        if (changedDataSetInTransaction == null) {
+            changedDataSetInTransaction = new HashSet<>();
+        }
+
+        changedDataSetInTransaction.add(schema);
+    }
+
+    public void fireForTransaction() {
+        Set<Schema<?>> schemaSet = changedDataSetInTransaction;
+        changedDataSetInTransaction = null;
+
+        if (schemaSet == null) {
+            return;
+        }
+        for (Map.Entry<Observer<DataSetChangedEvent<?>>, Selector<?, ?>> entry : observerMap.entrySet()) {
+            Selector<?, ?> selector = entry.getValue();
+            if (schemaSet.contains(selector.getSchema())) {
+                Observer<DataSetChangedEvent<?>> observer = entry.getKey();
+                observer.onNext(new DataSetChangedEvent<>(DataSetChangedEvent.Type.TRANSACTION, selector));
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaAdapter.java
@@ -20,8 +20,6 @@ import com.github.gfx.android.orma.Relation;
 import com.github.gfx.android.orma.exception.NoValueException;
 
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
@@ -38,11 +36,9 @@ import io.reactivex.Single;
  */
 public class OrmaAdapter<Model> {
 
-    final Context context;
+    protected final Context context;
 
-    final Relation<Model, ?> relation;
-
-    final Handler handler = new Handler(Looper.getMainLooper());
+    protected final Relation<Model, ?> relation;
 
     public OrmaAdapter(@NonNull Context context, @NonNull Relation<Model, ?> relation) {
         this.context = context;
@@ -66,10 +62,6 @@ public class OrmaAdapter<Model> {
     @NonNull
     public Relation<Model, ?> getRelation() {
         return relation.clone();
-    }
-
-    public void runOnUiThread(@NonNull final Runnable task) {
-        handler.postDelayed(task, 1000 / 30);
     }
 
     public Callable<Model> createFactory(final @NonNull Model model) {

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaListAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaListAdapter.java
@@ -18,7 +18,6 @@ package com.github.gfx.android.orma.widget;
 
 import com.github.gfx.android.orma.Relation;
 import com.github.gfx.android.orma.Selector;
-import com.github.gfx.android.orma.event.DataSetChangedEvent;
 
 import android.content.Context;
 import android.support.annotation.CheckResult;
@@ -42,7 +41,7 @@ public abstract class OrmaListAdapter<Model> extends BaseAdapter {
 
     protected final OrmaAdapter<Model> delegate;
 
-    private final Observable<DataSetChangedEvent<Selector<Model, ?>>> observable;
+    private final Observable<Selector<Model, ?>> observable;
 
     public OrmaListAdapter(@NonNull Context context, @NonNull Relation<Model, ?> relation) {
         this(new OrmaAdapter<>(context, relation));
@@ -54,9 +53,9 @@ public abstract class OrmaListAdapter<Model> extends BaseAdapter {
         observable = delegate.getRelation().createQueryObservable();
         observable.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Consumer<DataSetChangedEvent<Selector<Model, ?>>>() {
+                .subscribe(new Consumer<Selector<Model, ?>>() {
                     @Override
-                    public void accept(DataSetChangedEvent<Selector<Model, ?>> event) throws Exception {
+                    public void accept(Selector<Model, ?> selector) throws Exception {
                         notifyDataSetChanged();
                     }
                 });

--- a/library/src/main/java/com/github/gfx/android/orma/widget/OrmaRecyclerViewAdapter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/widget/OrmaRecyclerViewAdapter.java
@@ -18,7 +18,6 @@ package com.github.gfx.android.orma.widget;
 
 import com.github.gfx.android.orma.Relation;
 import com.github.gfx.android.orma.Selector;
-import com.github.gfx.android.orma.event.DataSetChangedEvent;
 
 import android.content.Context;
 import android.support.annotation.CheckResult;
@@ -46,7 +45,7 @@ public abstract class OrmaRecyclerViewAdapter<Model, VH extends RecyclerView.Vie
 
     protected final OrmaAdapter<Model> delegate;
 
-    protected final Observable<DataSetChangedEvent<Selector<Model, ?>>> observable;
+    protected final Observable<Selector<Model, ?>> observable;
 
     public OrmaRecyclerViewAdapter(@NonNull Context context, @NonNull Relation<Model, ?> relation) {
         this(new OrmaAdapter<>(context, relation));
@@ -58,16 +57,10 @@ public abstract class OrmaRecyclerViewAdapter<Model, VH extends RecyclerView.Vie
         observable = delegate.getRelation().createQueryObservable();
         observable.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Consumer<DataSetChangedEvent<Selector<Model, ?>>>() {
+                .subscribe(new Consumer<Selector<Model, ?>>() {
                     @Override
-                    public void accept(DataSetChangedEvent<Selector<Model, ?>> event) throws Exception {
-                        switch (event.getType()) {
-                            case INSERT:
-                            case UPDATE:
-                            case DELETE:
-                            case TRANSACTION:
-                                notifyDataSetChanged();
-                        }
+                    public void accept(Selector<Model, ?> selector) throws Exception {
+                        notifyDataSetChanged();
                     }
                 });
     }

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryObservableTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryObservableTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test;
+
+import com.github.gfx.android.orma.ModelFactory;
+import com.github.gfx.android.orma.test.model.Author;
+import com.github.gfx.android.orma.test.model.Author_Relation;
+import com.github.gfx.android.orma.test.model.OrmaDatabase;
+import com.github.gfx.android.orma.test.toolbox.OrmaFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.annotation.NonNull;
+import android.support.test.runner.AndroidJUnit4;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.reactivex.Observable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(AndroidJUnit4.class)
+public class QueryObservableTest {
+
+    OrmaDatabase db;
+
+    @Before
+    public void setUp() throws Exception {
+        db = OrmaFactory.create();
+
+        db.createAuthor(new ModelFactory<Author>() {
+            @NonNull
+            @Override
+            public Author call() {
+                return Author.create("foo");
+            }
+        });
+    }
+
+    @Test
+    public void triggerByInsert() throws Exception {
+        final List<String> result = new ArrayList<>();
+
+        Observable<Author_Relation> observable = db.relationOfAuthor().createQueryObservable();
+        observable.flatMap(new Function<Author_Relation, Observable<Author>>() {
+            @Override
+            public Observable<Author> apply(Author_Relation authors) throws Exception {
+                return authors.selector().executeAsObservable();
+            }
+        }).map(new Function<Author, String>() {
+            @Override
+            public String apply(Author author) throws Exception {
+                return author.name;
+            }
+        }).subscribe(new Consumer<String>() {
+            @Override
+            public void accept(String s) throws Exception {
+                result.add(s);
+            }
+        });
+
+        // trigger an event
+        db.createAuthor(new ModelFactory<Author>() {
+            @NonNull
+            @Override
+            public Author call() {
+                return Author.create("bar");
+            }
+        });
+        assertThat(result, contains("foo", "bar"));
+
+        // trigger another event
+        result.clear();
+        db.createAuthor(new ModelFactory<Author>() {
+            @NonNull
+            @Override
+            public Author call() {
+                return Author.create("baz");
+            }
+        });
+        assertThat(result, contains("foo", "bar", "baz"));
+    }
+}


### PR DESCRIPTION
* https://github.com/square/sqlbrite
* https://realm.io/docs/swift/latest/#notifications

example:

```java
final List<String> result = new ArrayList<>();

Observable<DataSetChangedEvent<Author_Selector>> observable = db.relationOfAuthor().createQueryObservable();
observable.flatMap(new Function<DataSetChangedEvent<Author_Selector>, Observable<Author>>() {
    @Override
    public Observable<Author> apply(DataSetChangedEvent<Author_Selector> event) throws Exception {
        return event.getSelector().executeAsObservable();
    }
}).map(new Function<Author, String>() {
    @Override
    public String apply(Author author) throws Exception {
        return author.name;
    }
}).subscribe(new Consumer<String>() {
    @Override
    public void accept(String s) throws Exception {
        result.add(s);
    }
});

// fire an event
db.insertIntoAuthor(Author.create("bar"));
assertThat(result, contains("foo", "bar"));

// fire another event
result.clear();
db.insertIntoAuthor(Author.create("baz"));
assertThat(result, contains("foo", "bar", "baz"));
```

See also the diff of OrmaListAdapter and OrmaRecyclerViewAdapter, which use query observables to invoke `notifyDataChanged()`.