### PR TITLE
use realm's insert api for better performance

### DIFF
--- a/example/src/main/java/com/github/gfx/android/orma/example/fragment/BenchmarkFragment.java
+++ b/example/src/main/java/com/github/gfx/android/orma/example/fragment/BenchmarkFragment.java
@@ -42,7 +42,9 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -227,13 +229,17 @@ public class BenchmarkFragment extends Fragment {
                 realm.executeTransaction(r -> {
                     long now = System.currentTimeMillis();
 
+                    List<RealmTodo> todos = new ArrayList<RealmTodo>();
                     for (int i = 0; i < N_ITEMS; i++) {
-                        RealmTodo todo = r.createObject(RealmTodo.class);
+                        RealmTodo todo = new RealmTodo();
 
                         todo.setTitle(titlePrefix + i);
                         todo.setContent(contentPrefix + i);
                         todo.setCreatedTime(new Date(now));
+
+                        todos.add(todo);
                     }
+                    realm.insert(todos);
                 });
                 realm.close();
             });


### PR DESCRIPTION
I updated realm's insert benchmark to use faster insert api.
https://realm.io/news/realm-java-1.1.0/

Result on Nexus6 7.0

before | after
--- | ---
![realm_createobject](https://cloud.githubusercontent.com/assets/654889/22319525/c75097fe-e3c6-11e6-90e9-03647f34f8c4.png) | ![realm_insert_api](https://cloud.githubusercontent.com/assets/654889/22319527/cdc4ea72-e3c6-11e6-8dfa-19b67bc45886.png)

Apparently Orma is much faster though :)