### PR TITLE
@RestrictTo should not be used for classes that are used for the generated

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/Selector.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Selector.java
@@ -165,7 +165,7 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
         }
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
     @SuppressWarnings("unchecked")
     public S resetLimitClause() {
         limit = -1;
@@ -174,23 +174,23 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
         return (S) this;
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
     public boolean hasLimit() {
         return limit != -1;
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
     public long getLimit() {
         assert hasLimit();
         return limit;
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
     public boolean hasOffset() {
         return offset != -1 || (limit != -1 && page != -1);
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
     public long getOffset() {
         assert hasOffset();
 

--- a/library/src/main/java/com/github/gfx/android/orma/internal/package-info.java
+++ b/library/src/main/java/com/github/gfx/android/orma/internal/package-info.java
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+/**
+ * This package provides internal utilities that are used in generated classes.
+ */
 package com.github.gfx.android.orma.internal;
 
-import android.support.annotation.RestrictTo;

--- a/migration/src/main/java/com/github/gfx/android/orma/migration/sqliteparser/package-info.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/sqliteparser/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@RestrictTo(RestrictTo.Scope.LIBRARY)
 package com.github.gfx.android.orma.migration.sqliteparser;
 
 import android.support.annotation.RestrictTo;


### PR DESCRIPTION
Restricting `com.github.gfx.android.orma.internal` is too strict that it causes lint errors because they are used in the generated classes.

`LIBRARY_GROUP` allows example to use them so I cannot find this issue in the project.