### PR TITLE
Generate helpers with deprecated annotations

### DIFF
--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Deleter.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Deleter.java
@@ -35,6 +35,56 @@ public class Category_Deleter extends Deleter<Category, Category_Deleter> {
     return schema;
   }
 
+  @Deprecated
+  public Category_Deleter nameEq(@NonNull String name) {
+    return where(schema.name, "=", name);
+  }
+
+  @Deprecated
+  public Category_Deleter nameNotEq(@NonNull String name) {
+    return where(schema.name, "<>", name);
+  }
+
+  @Deprecated
+  public Category_Deleter nameIn(@NonNull Collection<String> values) {
+    return in(false, schema.name, values);
+  }
+
+  @Deprecated
+  public Category_Deleter nameNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.name, values);
+  }
+
+  @Deprecated
+  public final Category_Deleter nameIn(@NonNull String... values) {
+    return nameIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Category_Deleter nameNotIn(@NonNull String... values) {
+    return nameNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Category_Deleter nameLt(@NonNull String name) {
+    return where(schema.name, "<", name);
+  }
+
+  @Deprecated
+  public Category_Deleter nameLe(@NonNull String name) {
+    return where(schema.name, "<=", name);
+  }
+
+  @Deprecated
+  public Category_Deleter nameGt(@NonNull String name) {
+    return where(schema.name, ">", name);
+  }
+
+  @Deprecated
+  public Category_Deleter nameGe(@NonNull String name) {
+    return where(schema.name, ">=", name);
+  }
+
   public Category_Deleter idEq(long id) {
     return where(schema.id, "=", id);
   }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Relation.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Relation.java
@@ -72,6 +72,56 @@ public class Category_Relation extends Relation<Category, Category_Relation> {
     return new Category_Deleter(this);
   }
 
+  @Deprecated
+  public Category_Relation nameEq(@NonNull String name) {
+    return where(schema.name, "=", name);
+  }
+
+  @Deprecated
+  public Category_Relation nameNotEq(@NonNull String name) {
+    return where(schema.name, "<>", name);
+  }
+
+  @Deprecated
+  public Category_Relation nameIn(@NonNull Collection<String> values) {
+    return in(false, schema.name, values);
+  }
+
+  @Deprecated
+  public Category_Relation nameNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.name, values);
+  }
+
+  @Deprecated
+  public final Category_Relation nameIn(@NonNull String... values) {
+    return nameIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Category_Relation nameNotIn(@NonNull String... values) {
+    return nameNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Category_Relation nameLt(@NonNull String name) {
+    return where(schema.name, "<", name);
+  }
+
+  @Deprecated
+  public Category_Relation nameLe(@NonNull String name) {
+    return where(schema.name, "<=", name);
+  }
+
+  @Deprecated
+  public Category_Relation nameGt(@NonNull String name) {
+    return where(schema.name, ">", name);
+  }
+
+  @Deprecated
+  public Category_Relation nameGe(@NonNull String name) {
+    return where(schema.name, ">=", name);
+  }
+
   public Category_Relation idEq(long id) {
     return where(schema.id, "=", id);
   }
@@ -117,5 +167,25 @@ public class Category_Relation extends Relation<Category, Category_Relation> {
    */
   public Category_Relation idBetween(long idA, long idB) {
     return whereBetween(schema.id, idA, idB);
+  }
+
+  @Deprecated
+  public Category_Relation orderByNameAsc() {
+    return orderBy(schema.name.orderInAscending());
+  }
+
+  @Deprecated
+  public Category_Relation orderByNameDesc() {
+    return orderBy(schema.name.orderInDescending());
+  }
+
+  @Deprecated
+  public Category_Relation orderByIdAsc() {
+    return orderBy(schema.id.orderInAscending());
+  }
+
+  @Deprecated
+  public Category_Relation orderByIdDesc() {
+    return orderBy(schema.id.orderInDescending());
   }
 }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Selector.java
@@ -35,6 +35,56 @@ public class Category_Selector extends Selector<Category, Category_Selector> {
     return schema;
   }
 
+  @Deprecated
+  public Category_Selector nameEq(@NonNull String name) {
+    return where(schema.name, "=", name);
+  }
+
+  @Deprecated
+  public Category_Selector nameNotEq(@NonNull String name) {
+    return where(schema.name, "<>", name);
+  }
+
+  @Deprecated
+  public Category_Selector nameIn(@NonNull Collection<String> values) {
+    return in(false, schema.name, values);
+  }
+
+  @Deprecated
+  public Category_Selector nameNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.name, values);
+  }
+
+  @Deprecated
+  public final Category_Selector nameIn(@NonNull String... values) {
+    return nameIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Category_Selector nameNotIn(@NonNull String... values) {
+    return nameNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Category_Selector nameLt(@NonNull String name) {
+    return where(schema.name, "<", name);
+  }
+
+  @Deprecated
+  public Category_Selector nameLe(@NonNull String name) {
+    return where(schema.name, "<=", name);
+  }
+
+  @Deprecated
+  public Category_Selector nameGt(@NonNull String name) {
+    return where(schema.name, ">", name);
+  }
+
+  @Deprecated
+  public Category_Selector nameGe(@NonNull String name) {
+    return where(schema.name, ">=", name);
+  }
+
   public Category_Selector idEq(long id) {
     return where(schema.id, "=", id);
   }
@@ -80,5 +130,25 @@ public class Category_Selector extends Selector<Category, Category_Selector> {
    */
   public Category_Selector idBetween(long idA, long idB) {
     return whereBetween(schema.id, idA, idB);
+  }
+
+  @Deprecated
+  public Category_Selector orderByNameAsc() {
+    return orderBy(schema.name.orderInAscending());
+  }
+
+  @Deprecated
+  public Category_Selector orderByNameDesc() {
+    return orderBy(schema.name.orderInDescending());
+  }
+
+  @Deprecated
+  public Category_Selector orderByIdAsc() {
+    return orderBy(schema.id.orderInAscending());
+  }
+
+  @Deprecated
+  public Category_Selector orderByIdDesc() {
+    return orderBy(schema.id.orderInDescending());
   }
 }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Updater.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Category_Updater.java
@@ -40,6 +40,56 @@ public class Category_Updater extends Updater<Category, Category_Updater> {
     return this;
   }
 
+  @Deprecated
+  public Category_Updater nameEq(@NonNull String name) {
+    return where(schema.name, "=", name);
+  }
+
+  @Deprecated
+  public Category_Updater nameNotEq(@NonNull String name) {
+    return where(schema.name, "<>", name);
+  }
+
+  @Deprecated
+  public Category_Updater nameIn(@NonNull Collection<String> values) {
+    return in(false, schema.name, values);
+  }
+
+  @Deprecated
+  public Category_Updater nameNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.name, values);
+  }
+
+  @Deprecated
+  public final Category_Updater nameIn(@NonNull String... values) {
+    return nameIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Category_Updater nameNotIn(@NonNull String... values) {
+    return nameNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Category_Updater nameLt(@NonNull String name) {
+    return where(schema.name, "<", name);
+  }
+
+  @Deprecated
+  public Category_Updater nameLe(@NonNull String name) {
+    return where(schema.name, "<=", name);
+  }
+
+  @Deprecated
+  public Category_Updater nameGt(@NonNull String name) {
+    return where(schema.name, ">", name);
+  }
+
+  @Deprecated
+  public Category_Updater nameGe(@NonNull String name) {
+    return where(schema.name, ">=", name);
+  }
+
   public Category_Updater idEq(long id) {
     return where(schema.id, "=", id);
   }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Deleter.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Deleter.java
@@ -35,6 +35,114 @@ public class Entry_Deleter extends Deleter<Entry, Entry_Deleter> {
     return schema;
   }
 
+  @Deprecated
+  public Entry_Deleter resourceTypeEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceTypeNotEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "<>", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceTypeIn(@NonNull Collection<String> values) {
+    return in(false, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceTypeNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public final Entry_Deleter resourceTypeIn(@NonNull String... values) {
+    return resourceTypeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Deleter resourceTypeNotIn(@NonNull String... values) {
+    return resourceTypeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceTypeLt(@NonNull String resourceType) {
+    return where(schema.resourceType, "<", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceTypeLe(@NonNull String resourceType) {
+    return where(schema.resourceType, "<=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceTypeGt(@NonNull String resourceType) {
+    return where(schema.resourceType, ">", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceTypeGe(@NonNull String resourceType) {
+    return where(schema.resourceType, ">=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdEq(long resourceId) {
+    return where(schema.resourceId, "=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdNotEq(long resourceId) {
+    return where(schema.resourceId, "<>", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdIn(@NonNull Collection<Long> values) {
+    return in(false, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdNotIn(@NonNull Collection<Long> values) {
+    return in(true, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public final Entry_Deleter resourceIdIn(@NonNull Long... values) {
+    return resourceIdIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Deleter resourceIdNotIn(@NonNull Long... values) {
+    return resourceIdNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdLt(long resourceId) {
+    return where(schema.resourceId, "<", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdLe(long resourceId) {
+    return where(schema.resourceId, "<=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdGt(long resourceId) {
+    return where(schema.resourceId, ">", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Deleter resourceIdGe(long resourceId) {
+    return where(schema.resourceId, ">=", resourceId);
+  }
+
+  /**
+   * To build a condition <code>resourceId BETWEEN a AND b</code>, which is equivalent to <code>a <= resourceId AND resourceId <= b</code>.
+   */
+  @Deprecated
+  public Entry_Deleter resourceIdBetween(long resourceIdA, long resourceIdB) {
+    return whereBetween(schema.resourceId, resourceIdA, resourceIdB);
+  }
+
   public Entry_Deleter idEq(long id) {
     return where(schema.id, "=", id);
   }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Relation.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Relation.java
@@ -73,6 +73,114 @@ public class Entry_Relation extends Relation<Entry, Entry_Relation> {
     return new Entry_Deleter(this);
   }
 
+  @Deprecated
+  public Entry_Relation resourceTypeEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceTypeNotEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "<>", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceTypeIn(@NonNull Collection<String> values) {
+    return in(false, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceTypeNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public final Entry_Relation resourceTypeIn(@NonNull String... values) {
+    return resourceTypeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Relation resourceTypeNotIn(@NonNull String... values) {
+    return resourceTypeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Relation resourceTypeLt(@NonNull String resourceType) {
+    return where(schema.resourceType, "<", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceTypeLe(@NonNull String resourceType) {
+    return where(schema.resourceType, "<=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceTypeGt(@NonNull String resourceType) {
+    return where(schema.resourceType, ">", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceTypeGe(@NonNull String resourceType) {
+    return where(schema.resourceType, ">=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdEq(long resourceId) {
+    return where(schema.resourceId, "=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdNotEq(long resourceId) {
+    return where(schema.resourceId, "<>", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdIn(@NonNull Collection<Long> values) {
+    return in(false, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdNotIn(@NonNull Collection<Long> values) {
+    return in(true, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public final Entry_Relation resourceIdIn(@NonNull Long... values) {
+    return resourceIdIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Relation resourceIdNotIn(@NonNull Long... values) {
+    return resourceIdNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdLt(long resourceId) {
+    return where(schema.resourceId, "<", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdLe(long resourceId) {
+    return where(schema.resourceId, "<=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdGt(long resourceId) {
+    return where(schema.resourceId, ">", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Relation resourceIdGe(long resourceId) {
+    return where(schema.resourceId, ">=", resourceId);
+  }
+
+  /**
+   * To build a condition <code>resourceId BETWEEN a AND b</code>, which is equivalent to <code>a <= resourceId AND resourceId <= b</code>.
+   */
+  @Deprecated
+  public Entry_Relation resourceIdBetween(long resourceIdA, long resourceIdB) {
+    return whereBetween(schema.resourceId, resourceIdA, resourceIdB);
+  }
+
   public Entry_Relation idEq(long id) {
     return where(schema.id, "=", id);
   }
@@ -122,6 +230,36 @@ public class Entry_Relation extends Relation<Entry, Entry_Relation> {
 
   public Entry_Relation resourceTypeAndResourceIdEq(@NonNull String resourceType, long resourceId) {
     return where(schema.resourceType, "=", resourceType).where(schema.resourceId, "=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Relation orderByResourceTypeAsc() {
+    return orderBy(schema.resourceType.orderInAscending());
+  }
+
+  @Deprecated
+  public Entry_Relation orderByResourceTypeDesc() {
+    return orderBy(schema.resourceType.orderInDescending());
+  }
+
+  @Deprecated
+  public Entry_Relation orderByResourceIdAsc() {
+    return orderBy(schema.resourceId.orderInAscending());
+  }
+
+  @Deprecated
+  public Entry_Relation orderByResourceIdDesc() {
+    return orderBy(schema.resourceId.orderInDescending());
+  }
+
+  @Deprecated
+  public Entry_Relation orderByIdAsc() {
+    return orderBy(schema.id.orderInAscending());
+  }
+
+  @Deprecated
+  public Entry_Relation orderByIdDesc() {
+    return orderBy(schema.id.orderInDescending());
   }
 
   public Entry_Relation orderByresourceTypeAndResourceIdAsc() {

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Selector.java
@@ -37,6 +37,114 @@ public class Entry_Selector extends Selector<Entry, Entry_Selector> {
     return schema;
   }
 
+  @Deprecated
+  public Entry_Selector resourceTypeEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceTypeNotEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "<>", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceTypeIn(@NonNull Collection<String> values) {
+    return in(false, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceTypeNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public final Entry_Selector resourceTypeIn(@NonNull String... values) {
+    return resourceTypeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Selector resourceTypeNotIn(@NonNull String... values) {
+    return resourceTypeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Selector resourceTypeLt(@NonNull String resourceType) {
+    return where(schema.resourceType, "<", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceTypeLe(@NonNull String resourceType) {
+    return where(schema.resourceType, "<=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceTypeGt(@NonNull String resourceType) {
+    return where(schema.resourceType, ">", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceTypeGe(@NonNull String resourceType) {
+    return where(schema.resourceType, ">=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdEq(long resourceId) {
+    return where(schema.resourceId, "=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdNotEq(long resourceId) {
+    return where(schema.resourceId, "<>", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdIn(@NonNull Collection<Long> values) {
+    return in(false, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdNotIn(@NonNull Collection<Long> values) {
+    return in(true, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public final Entry_Selector resourceIdIn(@NonNull Long... values) {
+    return resourceIdIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Selector resourceIdNotIn(@NonNull Long... values) {
+    return resourceIdNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdLt(long resourceId) {
+    return where(schema.resourceId, "<", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdLe(long resourceId) {
+    return where(schema.resourceId, "<=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdGt(long resourceId) {
+    return where(schema.resourceId, ">", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Selector resourceIdGe(long resourceId) {
+    return where(schema.resourceId, ">=", resourceId);
+  }
+
+  /**
+   * To build a condition <code>resourceId BETWEEN a AND b</code>, which is equivalent to <code>a <= resourceId AND resourceId <= b</code>.
+   */
+  @Deprecated
+  public Entry_Selector resourceIdBetween(long resourceIdA, long resourceIdB) {
+    return whereBetween(schema.resourceId, resourceIdA, resourceIdB);
+  }
+
   public Entry_Selector idEq(long id) {
     return where(schema.id, "=", id);
   }
@@ -86,6 +194,36 @@ public class Entry_Selector extends Selector<Entry, Entry_Selector> {
 
   public Entry_Selector resourceTypeAndResourceIdEq(@NonNull String resourceType, long resourceId) {
     return where(schema.resourceType, "=", resourceType).where(schema.resourceId, "=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Selector orderByResourceTypeAsc() {
+    return orderBy(schema.resourceType.orderInAscending());
+  }
+
+  @Deprecated
+  public Entry_Selector orderByResourceTypeDesc() {
+    return orderBy(schema.resourceType.orderInDescending());
+  }
+
+  @Deprecated
+  public Entry_Selector orderByResourceIdAsc() {
+    return orderBy(schema.resourceId.orderInAscending());
+  }
+
+  @Deprecated
+  public Entry_Selector orderByResourceIdDesc() {
+    return orderBy(schema.resourceId.orderInDescending());
+  }
+
+  @Deprecated
+  public Entry_Selector orderByIdAsc() {
+    return orderBy(schema.id.orderInAscending());
+  }
+
+  @Deprecated
+  public Entry_Selector orderByIdDesc() {
+    return orderBy(schema.id.orderInDescending());
   }
 
   public Entry_Selector orderByresourceTypeAndResourceIdAsc() {

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Updater.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Entry_Updater.java
@@ -45,6 +45,114 @@ public class Entry_Updater extends Updater<Entry, Entry_Updater> {
     return this;
   }
 
+  @Deprecated
+  public Entry_Updater resourceTypeEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceTypeNotEq(@NonNull String resourceType) {
+    return where(schema.resourceType, "<>", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceTypeIn(@NonNull Collection<String> values) {
+    return in(false, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceTypeNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.resourceType, values);
+  }
+
+  @Deprecated
+  public final Entry_Updater resourceTypeIn(@NonNull String... values) {
+    return resourceTypeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Updater resourceTypeNotIn(@NonNull String... values) {
+    return resourceTypeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Updater resourceTypeLt(@NonNull String resourceType) {
+    return where(schema.resourceType, "<", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceTypeLe(@NonNull String resourceType) {
+    return where(schema.resourceType, "<=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceTypeGt(@NonNull String resourceType) {
+    return where(schema.resourceType, ">", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceTypeGe(@NonNull String resourceType) {
+    return where(schema.resourceType, ">=", resourceType);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdEq(long resourceId) {
+    return where(schema.resourceId, "=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdNotEq(long resourceId) {
+    return where(schema.resourceId, "<>", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdIn(@NonNull Collection<Long> values) {
+    return in(false, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdNotIn(@NonNull Collection<Long> values) {
+    return in(true, schema.resourceId, values);
+  }
+
+  @Deprecated
+  public final Entry_Updater resourceIdIn(@NonNull Long... values) {
+    return resourceIdIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Entry_Updater resourceIdNotIn(@NonNull Long... values) {
+    return resourceIdNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdLt(long resourceId) {
+    return where(schema.resourceId, "<", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdLe(long resourceId) {
+    return where(schema.resourceId, "<=", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdGt(long resourceId) {
+    return where(schema.resourceId, ">", resourceId);
+  }
+
+  @Deprecated
+  public Entry_Updater resourceIdGe(long resourceId) {
+    return where(schema.resourceId, ">=", resourceId);
+  }
+
+  /**
+   * To build a condition <code>resourceId BETWEEN a AND b</code>, which is equivalent to <code>a <= resourceId AND resourceId <= b</code>.
+   */
+  @Deprecated
+  public Entry_Updater resourceIdBetween(long resourceIdA, long resourceIdB) {
+    return whereBetween(schema.resourceId, resourceIdA, resourceIdB);
+  }
+
   public Entry_Updater idEq(long id) {
     return where(schema.id, "=", id);
   }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Deleter.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Deleter.java
@@ -3,8 +3,12 @@ package com.github.gfx.android.orma.example.orma;
 import android.support.annotation.NonNull;
 import com.github.gfx.android.orma.Deleter;
 import com.github.gfx.android.orma.OrmaConnection;
+import com.github.gfx.android.orma.example.tool.TypeAdapters;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZonedDateTime;
 
 public class Item2_Deleter extends Deleter<Item2, Item2_Deleter> {
   final Item2_Schema schema;
@@ -57,6 +61,126 @@ public class Item2_Deleter extends Deleter<Item2, Item2_Deleter> {
 
   public Item2_Deleter category2Eq(long category2Id) {
     return where(schema.category2, "=", category2Id);
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampNotEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<>", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(false, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampNotIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(true, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Deleter zonedTimestampIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Deleter zonedTimestampNotIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampLt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampLe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampGt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Deleter zonedTimestampGe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeNotEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<>", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeIn(@NonNull Collection<LocalDateTime> values) {
+    return in(false, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeNotIn(@NonNull Collection<LocalDateTime> values) {
+    return in(true, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Deleter localDateTimeIn(@NonNull LocalDateTime... values) {
+    return localDateTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Deleter localDateTimeNotIn(@NonNull LocalDateTime... values) {
+    return localDateTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeLt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeLe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeGt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Deleter localDateTimeGe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">=", TypeAdapters.serializeLocalDateTime(localDateTime));
   }
 
   public Item2_Deleter nameEq(@NonNull String name) {

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Relation.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Relation.java
@@ -7,8 +7,11 @@ import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Relation;
 import com.github.gfx.android.orma.annotation.OnConflict;
 import com.github.gfx.android.orma.example.tool.TypeAdapters;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZonedDateTime;
 
 public class Item2_Relation extends Relation<Item2, Item2_Relation> {
   final Item2_Schema schema;
@@ -99,6 +102,126 @@ public class Item2_Relation extends Relation<Item2, Item2_Relation> {
     return where(schema.category2, "=", category2Id);
   }
 
+  @Deprecated
+  public Item2_Relation zonedTimestampEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Relation zonedTimestampNotEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<>", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Relation zonedTimestampIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(false, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Relation zonedTimestampNotIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(true, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Relation zonedTimestampIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Relation zonedTimestampNotIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Relation zonedTimestampLt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Relation zonedTimestampLe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Relation zonedTimestampGt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Relation zonedTimestampGe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeNotEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<>", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeIn(@NonNull Collection<LocalDateTime> values) {
+    return in(false, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeNotIn(@NonNull Collection<LocalDateTime> values) {
+    return in(true, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Relation localDateTimeIn(@NonNull LocalDateTime... values) {
+    return localDateTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Relation localDateTimeNotIn(@NonNull LocalDateTime... values) {
+    return localDateTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeLt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeLe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeGt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Relation localDateTimeGe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
   public Item2_Relation nameEq(@NonNull String name) {
     return where(schema.name, "=", name);
   }
@@ -153,6 +276,26 @@ public class Item2_Relation extends Relation<Item2, Item2_Relation> {
 
   public Item2_Relation orderByCategory2Desc() {
     return orderBy(schema.category2.orderInDescending());
+  }
+
+  @Deprecated
+  public Item2_Relation orderByZonedTimestampAsc() {
+    return orderBy(schema.zonedTimestamp.orderInAscending());
+  }
+
+  @Deprecated
+  public Item2_Relation orderByZonedTimestampDesc() {
+    return orderBy(schema.zonedTimestamp.orderInDescending());
+  }
+
+  @Deprecated
+  public Item2_Relation orderByLocalDateTimeAsc() {
+    return orderBy(schema.localDateTime.orderInAscending());
+  }
+
+  @Deprecated
+  public Item2_Relation orderByLocalDateTimeDesc() {
+    return orderBy(schema.localDateTime.orderInDescending());
   }
 
   public Item2_Relation orderByNameAsc() {

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Selector.java
@@ -3,8 +3,12 @@ package com.github.gfx.android.orma.example.orma;
 import android.support.annotation.NonNull;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Selector;
+import com.github.gfx.android.orma.example.tool.TypeAdapters;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZonedDateTime;
 
 public class Item2_Selector extends Selector<Item2, Item2_Selector> {
   final Item2_Schema schema;
@@ -57,6 +61,126 @@ public class Item2_Selector extends Selector<Item2, Item2_Selector> {
 
   public Item2_Selector category2Eq(long category2Id) {
     return where(schema.category2, "=", category2Id);
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampNotEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<>", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(false, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampNotIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(true, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Selector zonedTimestampIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Selector zonedTimestampNotIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampLt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampLe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampGt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Selector zonedTimestampGe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeNotEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<>", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeIn(@NonNull Collection<LocalDateTime> values) {
+    return in(false, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeNotIn(@NonNull Collection<LocalDateTime> values) {
+    return in(true, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Selector localDateTimeIn(@NonNull LocalDateTime... values) {
+    return localDateTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Selector localDateTimeNotIn(@NonNull LocalDateTime... values) {
+    return localDateTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeLt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeLe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeGt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Selector localDateTimeGe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">=", TypeAdapters.serializeLocalDateTime(localDateTime));
   }
 
   public Item2_Selector nameEq(@NonNull String name) {
@@ -113,6 +237,26 @@ public class Item2_Selector extends Selector<Item2, Item2_Selector> {
 
   public Item2_Selector orderByCategory2Desc() {
     return orderBy(schema.category2.orderInDescending());
+  }
+
+  @Deprecated
+  public Item2_Selector orderByZonedTimestampAsc() {
+    return orderBy(schema.zonedTimestamp.orderInAscending());
+  }
+
+  @Deprecated
+  public Item2_Selector orderByZonedTimestampDesc() {
+    return orderBy(schema.zonedTimestamp.orderInDescending());
+  }
+
+  @Deprecated
+  public Item2_Selector orderByLocalDateTimeAsc() {
+    return orderBy(schema.localDateTime.orderInAscending());
+  }
+
+  @Deprecated
+  public Item2_Selector orderByLocalDateTimeDesc() {
+    return orderBy(schema.localDateTime.orderInDescending());
   }
 
   public Item2_Selector orderByNameAsc() {

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Updater.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Item2_Updater.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Updater;
 import com.github.gfx.android.orma.example.tool.TypeAdapters;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
 import org.threeten.bp.LocalDateTime;
@@ -86,6 +87,126 @@ public class Item2_Updater extends Updater<Item2, Item2_Updater> {
 
   public Item2_Updater category2Eq(long category2Id) {
     return where(schema.category2, "=", category2Id);
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampNotEq(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<>", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(false, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampNotIn(@NonNull Collection<ZonedDateTime> values) {
+    return in(true, schema.zonedTimestamp, values, new Function1<ZonedDateTime, String>() {
+      @Override
+      public String apply(ZonedDateTime value) {
+        return TypeAdapters.serializeZonedDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Updater zonedTimestampIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Updater zonedTimestampNotIn(@NonNull ZonedDateTime... values) {
+    return zonedTimestampNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampLt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampLe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, "<=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampGt(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Updater zonedTimestampGe(@NonNull ZonedDateTime zonedTimestamp) {
+    return where(schema.zonedTimestamp, ">=", TypeAdapters.serializeZonedDateTime(zonedTimestamp));
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeNotEq(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<>", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeIn(@NonNull Collection<LocalDateTime> values) {
+    return in(false, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeNotIn(@NonNull Collection<LocalDateTime> values) {
+    return in(true, schema.localDateTime, values, new Function1<LocalDateTime, String>() {
+      @Override
+      public String apply(LocalDateTime value) {
+        return TypeAdapters.serializeLocalDateTime(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Item2_Updater localDateTimeIn(@NonNull LocalDateTime... values) {
+    return localDateTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Item2_Updater localDateTimeNotIn(@NonNull LocalDateTime... values) {
+    return localDateTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeLt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeLe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, "<=", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeGt(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">", TypeAdapters.serializeLocalDateTime(localDateTime));
+  }
+
+  @Deprecated
+  public Item2_Updater localDateTimeGe(@NonNull LocalDateTime localDateTime) {
+    return where(schema.localDateTime, ">=", TypeAdapters.serializeLocalDateTime(localDateTime));
   }
 
   public Item2_Updater nameEq(@NonNull String name) {

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Deleter.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Deleter.java
@@ -1,10 +1,13 @@
 package com.github.gfx.android.orma.example.orma;
 
 import android.support.annotation.NonNull;
+import com.github.gfx.android.orma.BuiltInSerializers;
 import com.github.gfx.android.orma.Deleter;
 import com.github.gfx.android.orma.OrmaConnection;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 
 public class Todo_Deleter extends Deleter<Todo, Todo_Deleter> {
   final Todo_Schema schema;
@@ -75,6 +78,66 @@ public class Todo_Deleter extends Deleter<Todo, Todo_Deleter> {
     return where(schema.title, ">=", title);
   }
 
+  @Deprecated
+  public Todo_Deleter contentIsNull() {
+    return where(schema.content, " IS NULL");
+  }
+
+  @Deprecated
+  public Todo_Deleter contentIsNotNull() {
+    return where(schema.content, " IS NOT NULL");
+  }
+
+  @Deprecated
+  public Todo_Deleter contentEq(@NonNull String content) {
+    return where(schema.content, "=", content);
+  }
+
+  @Deprecated
+  public Todo_Deleter contentNotEq(@NonNull String content) {
+    return where(schema.content, "<>", content);
+  }
+
+  @Deprecated
+  public Todo_Deleter contentIn(@NonNull Collection<String> values) {
+    return in(false, schema.content, values);
+  }
+
+  @Deprecated
+  public Todo_Deleter contentNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.content, values);
+  }
+
+  @Deprecated
+  public final Todo_Deleter contentIn(@NonNull String... values) {
+    return contentIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Deleter contentNotIn(@NonNull String... values) {
+    return contentNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Deleter contentLt(@NonNull String content) {
+    return where(schema.content, "<", content);
+  }
+
+  @Deprecated
+  public Todo_Deleter contentLe(@NonNull String content) {
+    return where(schema.content, "<=", content);
+  }
+
+  @Deprecated
+  public Todo_Deleter contentGt(@NonNull String content) {
+    return where(schema.content, ">", content);
+  }
+
+  @Deprecated
+  public Todo_Deleter contentGe(@NonNull String content) {
+    return where(schema.content, ">=", content);
+  }
+
   public Todo_Deleter doneEq(boolean done) {
     return where(schema.done, "=", done);
   }
@@ -113,6 +176,74 @@ public class Todo_Deleter extends Deleter<Todo, Todo_Deleter> {
 
   public Todo_Deleter doneGe(boolean done) {
     return where(schema.done, ">=", done);
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeNotEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<>", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeIn(@NonNull Collection<Date> values) {
+    return in(false, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeNotIn(@NonNull Collection<Date> values) {
+    return in(true, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Todo_Deleter createdTimeIn(@NonNull Date... values) {
+    return createdTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Deleter createdTimeNotIn(@NonNull Date... values) {
+    return createdTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeLt(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeLe(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeGt(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Deleter createdTimeGe(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  /**
+   * To build a condition <code>createdTime BETWEEN a AND b</code>, which is equivalent to <code>a <= createdTime AND createdTime <= b</code>.
+   */
+  @Deprecated
+  public Todo_Deleter createdTimeBetween(@NonNull Date createdTimeA, @NonNull Date createdTimeB) {
+    return whereBetween(schema.createdTime, BuiltInSerializers.serializeDate(createdTimeA), BuiltInSerializers.serializeDate(createdTimeB));
   }
 
   public Todo_Deleter idEq(long id) {

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Relation.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Relation.java
@@ -7,8 +7,10 @@ import com.github.gfx.android.orma.BuiltInSerializers;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Relation;
 import com.github.gfx.android.orma.annotation.OnConflict;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 
 public class Todo_Relation extends Relation<Todo, Todo_Relation> {
   final Todo_Schema schema;
@@ -116,6 +118,66 @@ public class Todo_Relation extends Relation<Todo, Todo_Relation> {
     return where(schema.title, ">=", title);
   }
 
+  @Deprecated
+  public Todo_Relation contentIsNull() {
+    return where(schema.content, " IS NULL");
+  }
+
+  @Deprecated
+  public Todo_Relation contentIsNotNull() {
+    return where(schema.content, " IS NOT NULL");
+  }
+
+  @Deprecated
+  public Todo_Relation contentEq(@NonNull String content) {
+    return where(schema.content, "=", content);
+  }
+
+  @Deprecated
+  public Todo_Relation contentNotEq(@NonNull String content) {
+    return where(schema.content, "<>", content);
+  }
+
+  @Deprecated
+  public Todo_Relation contentIn(@NonNull Collection<String> values) {
+    return in(false, schema.content, values);
+  }
+
+  @Deprecated
+  public Todo_Relation contentNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.content, values);
+  }
+
+  @Deprecated
+  public final Todo_Relation contentIn(@NonNull String... values) {
+    return contentIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Relation contentNotIn(@NonNull String... values) {
+    return contentNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Relation contentLt(@NonNull String content) {
+    return where(schema.content, "<", content);
+  }
+
+  @Deprecated
+  public Todo_Relation contentLe(@NonNull String content) {
+    return where(schema.content, "<=", content);
+  }
+
+  @Deprecated
+  public Todo_Relation contentGt(@NonNull String content) {
+    return where(schema.content, ">", content);
+  }
+
+  @Deprecated
+  public Todo_Relation contentGe(@NonNull String content) {
+    return where(schema.content, ">=", content);
+  }
+
   public Todo_Relation doneEq(boolean done) {
     return where(schema.done, "=", done);
   }
@@ -154,6 +216,74 @@ public class Todo_Relation extends Relation<Todo, Todo_Relation> {
 
   public Todo_Relation doneGe(boolean done) {
     return where(schema.done, ">=", done);
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeNotEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<>", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeIn(@NonNull Collection<Date> values) {
+    return in(false, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeNotIn(@NonNull Collection<Date> values) {
+    return in(true, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Todo_Relation createdTimeIn(@NonNull Date... values) {
+    return createdTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Relation createdTimeNotIn(@NonNull Date... values) {
+    return createdTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeLt(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeLe(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeGt(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Relation createdTimeGe(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  /**
+   * To build a condition <code>createdTime BETWEEN a AND b</code>, which is equivalent to <code>a <= createdTime AND createdTime <= b</code>.
+   */
+  @Deprecated
+  public Todo_Relation createdTimeBetween(@NonNull Date createdTimeA, @NonNull Date createdTimeB) {
+    return whereBetween(schema.createdTime, BuiltInSerializers.serializeDate(createdTimeA), BuiltInSerializers.serializeDate(createdTimeB));
   }
 
   public Todo_Relation idEq(long id) {
@@ -211,6 +341,16 @@ public class Todo_Relation extends Relation<Todo, Todo_Relation> {
     return orderBy(schema.title.orderInDescending());
   }
 
+  @Deprecated
+  public Todo_Relation orderByContentAsc() {
+    return orderBy(schema.content.orderInAscending());
+  }
+
+  @Deprecated
+  public Todo_Relation orderByContentDesc() {
+    return orderBy(schema.content.orderInDescending());
+  }
+
   public Todo_Relation orderByDoneAsc() {
     return orderBy(schema.done.orderInAscending());
   }
@@ -225,5 +365,15 @@ public class Todo_Relation extends Relation<Todo, Todo_Relation> {
 
   public Todo_Relation orderByCreatedTimeDesc() {
     return orderBy(schema.createdTime.orderInDescending());
+  }
+
+  @Deprecated
+  public Todo_Relation orderByIdAsc() {
+    return orderBy(schema.id.orderInAscending());
+  }
+
+  @Deprecated
+  public Todo_Relation orderByIdDesc() {
+    return orderBy(schema.id.orderInDescending());
   }
 }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Selector.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Selector.java
@@ -1,10 +1,13 @@
 package com.github.gfx.android.orma.example.orma;
 
 import android.support.annotation.NonNull;
+import com.github.gfx.android.orma.BuiltInSerializers;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Selector;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 
 public class Todo_Selector extends Selector<Todo, Todo_Selector> {
   final Todo_Schema schema;
@@ -75,6 +78,66 @@ public class Todo_Selector extends Selector<Todo, Todo_Selector> {
     return where(schema.title, ">=", title);
   }
 
+  @Deprecated
+  public Todo_Selector contentIsNull() {
+    return where(schema.content, " IS NULL");
+  }
+
+  @Deprecated
+  public Todo_Selector contentIsNotNull() {
+    return where(schema.content, " IS NOT NULL");
+  }
+
+  @Deprecated
+  public Todo_Selector contentEq(@NonNull String content) {
+    return where(schema.content, "=", content);
+  }
+
+  @Deprecated
+  public Todo_Selector contentNotEq(@NonNull String content) {
+    return where(schema.content, "<>", content);
+  }
+
+  @Deprecated
+  public Todo_Selector contentIn(@NonNull Collection<String> values) {
+    return in(false, schema.content, values);
+  }
+
+  @Deprecated
+  public Todo_Selector contentNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.content, values);
+  }
+
+  @Deprecated
+  public final Todo_Selector contentIn(@NonNull String... values) {
+    return contentIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Selector contentNotIn(@NonNull String... values) {
+    return contentNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Selector contentLt(@NonNull String content) {
+    return where(schema.content, "<", content);
+  }
+
+  @Deprecated
+  public Todo_Selector contentLe(@NonNull String content) {
+    return where(schema.content, "<=", content);
+  }
+
+  @Deprecated
+  public Todo_Selector contentGt(@NonNull String content) {
+    return where(schema.content, ">", content);
+  }
+
+  @Deprecated
+  public Todo_Selector contentGe(@NonNull String content) {
+    return where(schema.content, ">=", content);
+  }
+
   public Todo_Selector doneEq(boolean done) {
     return where(schema.done, "=", done);
   }
@@ -113,6 +176,74 @@ public class Todo_Selector extends Selector<Todo, Todo_Selector> {
 
   public Todo_Selector doneGe(boolean done) {
     return where(schema.done, ">=", done);
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeNotEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<>", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeIn(@NonNull Collection<Date> values) {
+    return in(false, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeNotIn(@NonNull Collection<Date> values) {
+    return in(true, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Todo_Selector createdTimeIn(@NonNull Date... values) {
+    return createdTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Selector createdTimeNotIn(@NonNull Date... values) {
+    return createdTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeLt(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeLe(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeGt(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Selector createdTimeGe(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  /**
+   * To build a condition <code>createdTime BETWEEN a AND b</code>, which is equivalent to <code>a <= createdTime AND createdTime <= b</code>.
+   */
+  @Deprecated
+  public Todo_Selector createdTimeBetween(@NonNull Date createdTimeA, @NonNull Date createdTimeB) {
+    return whereBetween(schema.createdTime, BuiltInSerializers.serializeDate(createdTimeA), BuiltInSerializers.serializeDate(createdTimeB));
   }
 
   public Todo_Selector idEq(long id) {
@@ -170,6 +301,16 @@ public class Todo_Selector extends Selector<Todo, Todo_Selector> {
     return orderBy(schema.title.orderInDescending());
   }
 
+  @Deprecated
+  public Todo_Selector orderByContentAsc() {
+    return orderBy(schema.content.orderInAscending());
+  }
+
+  @Deprecated
+  public Todo_Selector orderByContentDesc() {
+    return orderBy(schema.content.orderInDescending());
+  }
+
   public Todo_Selector orderByDoneAsc() {
     return orderBy(schema.done.orderInAscending());
   }
@@ -184,5 +325,15 @@ public class Todo_Selector extends Selector<Todo, Todo_Selector> {
 
   public Todo_Selector orderByCreatedTimeDesc() {
     return orderBy(schema.createdTime.orderInDescending());
+  }
+
+  @Deprecated
+  public Todo_Selector orderByIdAsc() {
+    return orderBy(schema.id.orderInAscending());
+  }
+
+  @Deprecated
+  public Todo_Selector orderByIdDesc() {
+    return orderBy(schema.id.orderInDescending());
   }
 }

--- a/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Updater.java
+++ b/example/build/generated/source/apt/debug/com/github/gfx/android/orma/example/orma/Todo_Updater.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import com.github.gfx.android.orma.BuiltInSerializers;
 import com.github.gfx.android.orma.OrmaConnection;
 import com.github.gfx.android.orma.Updater;
+import com.github.gfx.android.orma.function.Function1;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -103,6 +104,66 @@ public class Todo_Updater extends Updater<Todo, Todo_Updater> {
     return where(schema.title, ">=", title);
   }
 
+  @Deprecated
+  public Todo_Updater contentIsNull() {
+    return where(schema.content, " IS NULL");
+  }
+
+  @Deprecated
+  public Todo_Updater contentIsNotNull() {
+    return where(schema.content, " IS NOT NULL");
+  }
+
+  @Deprecated
+  public Todo_Updater contentEq(@NonNull String content) {
+    return where(schema.content, "=", content);
+  }
+
+  @Deprecated
+  public Todo_Updater contentNotEq(@NonNull String content) {
+    return where(schema.content, "<>", content);
+  }
+
+  @Deprecated
+  public Todo_Updater contentIn(@NonNull Collection<String> values) {
+    return in(false, schema.content, values);
+  }
+
+  @Deprecated
+  public Todo_Updater contentNotIn(@NonNull Collection<String> values) {
+    return in(true, schema.content, values);
+  }
+
+  @Deprecated
+  public final Todo_Updater contentIn(@NonNull String... values) {
+    return contentIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Updater contentNotIn(@NonNull String... values) {
+    return contentNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Updater contentLt(@NonNull String content) {
+    return where(schema.content, "<", content);
+  }
+
+  @Deprecated
+  public Todo_Updater contentLe(@NonNull String content) {
+    return where(schema.content, "<=", content);
+  }
+
+  @Deprecated
+  public Todo_Updater contentGt(@NonNull String content) {
+    return where(schema.content, ">", content);
+  }
+
+  @Deprecated
+  public Todo_Updater contentGe(@NonNull String content) {
+    return where(schema.content, ">=", content);
+  }
+
   public Todo_Updater doneEq(boolean done) {
     return where(schema.done, "=", done);
   }
@@ -141,6 +202,74 @@ public class Todo_Updater extends Updater<Todo, Todo_Updater> {
 
   public Todo_Updater doneGe(boolean done) {
     return where(schema.done, ">=", done);
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeNotEq(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<>", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeIn(@NonNull Collection<Date> values) {
+    return in(false, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeNotIn(@NonNull Collection<Date> values) {
+    return in(true, schema.createdTime, values, new Function1<Date, Long>() {
+      @Override
+      public Long apply(Date value) {
+        return BuiltInSerializers.serializeDate(value);
+      }
+    });
+  }
+
+  @Deprecated
+  public final Todo_Updater createdTimeIn(@NonNull Date... values) {
+    return createdTimeIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public final Todo_Updater createdTimeNotIn(@NonNull Date... values) {
+    return createdTimeNotIn(Arrays.asList(values));
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeLt(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeLe(@NonNull Date createdTime) {
+    return where(schema.createdTime, "<=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeGt(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  @Deprecated
+  public Todo_Updater createdTimeGe(@NonNull Date createdTime) {
+    return where(schema.createdTime, ">=", BuiltInSerializers.serializeDate(createdTime));
+  }
+
+  /**
+   * To build a condition <code>createdTime BETWEEN a AND b</code>, which is equivalent to <code>a <= createdTime AND createdTime <= b</code>.
+   */
+  @Deprecated
+  public Todo_Updater createdTimeBetween(@NonNull Date createdTimeA, @NonNull Date createdTimeB) {
+    return whereBetween(schema.createdTime, BuiltInSerializers.serializeDate(createdTimeA), BuiltInSerializers.serializeDate(createdTimeB));
   }
 
   public Todo_Updater idEq(long id) {

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/util/Annotations.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/util/Annotations.java
@@ -37,8 +37,6 @@ public class Annotations {
 
     private static final AnnotationSpec checkResult = AnnotationSpec.builder(Types.CheckResult).build();
 
-    private static final AnnotationSpec deprecated = AnnotationSpec.builder(Deprecated.class).build();
-
     private static final List<AnnotationSpec> safeVarArgsAnnotations = Arrays.asList(
             AnnotationSpec.builder(SafeVarargs.class).build(),
             suppressWarnings("varargs")
@@ -52,6 +50,10 @@ public class Annotations {
     private static List<AnnotationSpec> overrideAndNullable = Arrays.asList(
             Annotations.nullable(),
             Annotations.override()
+    );
+
+    private static List<AnnotationSpec> deprecated = Collections.singletonList(
+            AnnotationSpec.builder(Deprecated.class).build()
     );
 
     public static AnnotationSpec override() {
@@ -87,6 +89,18 @@ public class Annotations {
         }
     }
 
+    public static List<AnnotationSpec> deprecatedIf(boolean needed) {
+        if (needed) {
+            return deprecated;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    public static List<AnnotationSpec> deprecatedUnless(boolean notNeeded) {
+        return deprecatedIf(!notNeeded);
+    }
+
     public static AnnotationSpec suppressWarnings(String... warnings) {
         AnnotationSpec.Builder builder = AnnotationSpec.builder(SuppressWarnings.class);
         CodeBlock.Builder names = CodeBlock.builder();
@@ -105,10 +119,6 @@ public class Annotations {
             builder.addMember("value", "{$L}", names.build());
         }
         return builder.build();
-    }
-
-    public static AnnotationSpec deprecated() {
-        return deprecated;
     }
 
     public static AnnotationSpec checkResult() {


### PR DESCRIPTION
From the beginning of Orma, it does not generates query helper methods for columns without `indexed = true`.

I believe this is one of the most useful inventions of Orma, but on the other hand, it is confusing for Orma beginners and there are few hints to generate these helpers.

Instead, with this PR Orma always generates helpers for all the columns, but add `@Deprecated` if a column is not indexed, meaning "you can use it but is not recommended".

Any comments?