### PR TITLE
change Selector#value() to respect Selector#offset()

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/Selector.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Selector.java
@@ -240,7 +240,7 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
     @Nullable
     public Model getOrNull(@IntRange(from = 0) long position) {
         return conn.querySingle(getSchema(), getSchema().getDefaultResultColumns(),
-                getWhereClause(), getBindArgs(), groupBy, having, orderBy, position);
+                getWhereClause(), getBindArgs(), groupBy, having, orderBy, position + Math.max(offset, 0));
     }
 
     @NonNull

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
@@ -162,6 +162,14 @@ public class QueryTest {
         assertThat(book, is(nullValue()));
     }
 
+    @Test
+    public void valueWithOffset() throws Exception {
+        Book book = db.selectFromBook().offset(1).value();
+
+        assertThat(book.title, is("friday"));
+        assertThat(book.content, is("apple"));
+    }
+
     @Test(expected = NoValueException.class)
     public void valueIfNull() throws Exception {
         db.deleteFromBook().execute();
@@ -189,6 +197,14 @@ public class QueryTest {
         assert book != null;
         assertThat(book.bookId, is(db.selectFromBook().get(0).bookId));
         assertThat(db.selectFromBook().get(10), is(nullValue()));
+    }
+
+    @Test
+    public void testGetWithOffset() throws Exception {
+        Book book = db.selectFromBook().offset(1).get(0);
+
+        assertThat(book.title, is("friday"));
+        assertThat(book.content, is("apple"));
     }
 
     @Test


### PR DESCRIPTION
Currently, `Selector#value()` and `Selector#valueOrNull()` returns the first model whether or not to specify `Selector#offset()`.

```java
orma.selectFromTodo()
    .offset(10)
    .value(); // returns the 1st todo without any warning!
```

Of course we can do the aimed thing as

```java
orma.selectFromTodo().get(10);
```

but current behavior makes me a little confusable.

So I changed these methods to respects `offset`.
How do you think?