### PR TITLE
add close() into OrmaConnection

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
+++ b/library/src/main/java/com/github/gfx/android/orma/OrmaConnection.java
@@ -404,6 +404,15 @@ public class OrmaConnection {
         db.execSQL(sql, bindArgs);
     }
 
+    /**
+     * Close this connection.
+     *
+     * All queries are no longer acceptable unless the database is re-build.
+     */
+    public void close() {
+        db.close();
+    }
+
     protected void checkSchemas(List<Schema<?>> schemas) {
         if (tryParsingSql) {
             for (Schema<?> schema : schemas) {


### PR DESCRIPTION
Title says everything.
Some situations require  close and re-build database, `close()` method allow us to do it.