### PR TITLE
Cleanup condition group

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/Relation.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Relation.java
@@ -222,7 +222,7 @@ public abstract class Relation<Model, R extends Relation<Model, ?>> extends Orma
     }
 
     @Override
-    public abstract R clone();
+    public abstract Relation<Model, R> clone();
 
     /**
      * {@code selector()} creates a {@link Selector} with queries that the relation has.

--- a/library/src/main/java/com/github/gfx/android/orma/Selector.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Selector.java
@@ -82,7 +82,7 @@ public abstract class Selector<Model, S extends Selector<Model, ?>>
     }
 
     @Override
-    public abstract S clone();
+    public abstract Selector<Model, S> clone();
 
     @NonNull
     @Override

--- a/library/src/main/java/com/github/gfx/android/orma/Updater.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Updater.java
@@ -42,6 +42,7 @@ public abstract class Updater<Model, U extends Updater<Model, ?>> extends OrmaCo
         super(relation);
     }
 
+    @Override
     public abstract Updater<Model, U> clone();
 
     @NonNull

--- a/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
+++ b/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
@@ -33,8 +33,6 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
 
     protected String whereConjunction = " AND ";
 
-    private boolean skipConjunction = false;
-
     @Nullable
     protected StringBuilder whereClause;
 
@@ -87,8 +85,6 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
     public C where(@NonNull CharSequence conditions, @NonNull Object... args) {
         if (whereClause == null) {
             whereClause = new StringBuilder(conditions.length() + 2);
-        } else if (skipConjunction) {
-            skipConjunction = false;
         } else {
             whereClause.append(whereConjunction);
         }
@@ -184,7 +180,6 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
     @SuppressWarnings("unchecked")
     public C where(@NonNull Function1<C, C> block) {
         String currentConjunction = whereConjunction;
-        skipConjunction = true;
 
         if (whereClause == null) {
             whereClause = new StringBuilder();

--- a/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
+++ b/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model, ?>> {
+public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model, ?>> implements Cloneable {
 
     protected final OrmaConnection conn;
 
@@ -47,6 +47,9 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
         this(condition.conn);
         where(condition);
     }
+
+    @Override
+    abstract public OrmaConditionBase<Model, C> clone();
 
     public OrmaConnection getConnection() {
         return conn;
@@ -179,20 +182,7 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
      */
     @SuppressWarnings("unchecked")
     public C where(@NonNull Function1<C, C> block) {
-        String currentConjunction = whereConjunction;
-
-        if (whereClause == null) {
-            whereClause = new StringBuilder();
-        } else {
-            whereClause.append(whereConjunction);
-        }
-
-        whereClause.append('(');
-        block.apply((C) this);
-        whereClause.append(')');
-
-        whereConjunction = currentConjunction;
-        return (C) this;
+        return where(block.apply((C) clone()));
     }
 
     @SuppressWarnings("unchecked")

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
@@ -349,44 +349,18 @@ public class QueryTest {
     }
 
     @Test
-    public void whereConditionGroup() throws Exception {
-        List<Book> books = db.selectFromBook()
-                .titleEq("today").or().where("content GLOB ?", "*,*")
-                .and()
-                .titleGlob("fri*")
-                .toList();
-        assertThat(books, hasSize(1));
-
-        Book_Selector condition = db.selectFromBook()
-                .titleEq("today").or().where("content GLOB ?", "*,*");
-        books = db.selectFromBook()
-                .where(condition)
-                .and()
-                .titleGlob("fri*")
-                .toList();
-        assertThat(books, hasSize(0));
-    }
-
-    @Test
     public void whereConditionGroupFunction() throws Exception {
         List<Book> books = db.selectFromBook()
-                .titleEq("today").or().where("content GLOB ?", "*,*")
-                .and()
-                .titleGlob("fri*")
-                .toList();
-        assertThat(books, hasSize(1));
-
-        books = db.selectFromBook()
                 .where(new Function1<Book_Selector, Book_Selector>() {
                     @Override
                     public Book_Selector apply(Book_Selector it) {
-                        return it.titleEq("today").or().where("content GLOB ?", "*,*");
+                        return it.titleEq("today").or().titleEq("friday");
                     }
                 })
                 .and()
-                .titleGlob("fri*")
+                .priceGe(100)
                 .toList();
-        assertThat(books, hasSize(0));
+        assertThat(books, hasSize(2));
     }
 
     @Test

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/Book.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/Book.java
@@ -38,7 +38,7 @@ public class Book {
     @Column
     public boolean inPrint;
 
-    @Column
+    @Column(indexed = true)
     public long price = 100;
 
     @Column(indexed = true)


### PR DESCRIPTION
`where(Function<C, C>)` is just an alias to `where(block.apply((C) clone()))`

`clone()` makes it a real function without side-effect.

cc: @k-kagurazaka  