### PR TITLE
ensure to close statements in OrmaDatabase#insertInto*()

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/Inserter.java
+++ b/library/src/main/java/com/github/gfx/android/orma/Inserter.java
@@ -96,6 +96,19 @@ public class Inserter<Model> implements Closeable {
     }
 
     /**
+     * Does {@link #execute(Object)} and then does {@link #close()} immediately
+     * @param model A model to insert
+     * @return A last-inserted row id
+     */
+    public long executeAndClose(@NonNull Model model) {
+        try {
+            return execute(model);
+        } finally {
+            close();
+        }
+    }
+
+    /**
      * {@link Single} wrapper to {@code execute(Model)}
      *
      * @param model A model object to insert

--- a/processor/src/main/java/com/github/gfx/android/orma/processor/generator/DatabaseWriter.java
+++ b/processor/src/main/java/com/github/gfx/android/orma/processor/generator/DatabaseWriter.java
@@ -419,7 +419,7 @@ public class DatabaseWriter extends BaseWriter {
                                             .addAnnotation(Annotations.nonNull())
                                             .build()
                             )
-                            .addStatement("return prepareInsertInto$L().execute(model)",
+                            .addStatement("return prepareInsertInto$L().executeAndClose(model)",
                                     simpleModelName
                             )
                             .build());


### PR DESCRIPTION
#409 

It seems that SQLCipher is a bit more strict than platform's SQLiteDatabase.