### PR TITLE
fix a bug that where(block) includes duplicated clause

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
+++ b/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
@@ -182,7 +182,7 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
      */
     @SuppressWarnings("unchecked")
     public C where(@NonNull Function1<C, C> block) {
-        return where(block.apply((C) clone()));
+        return block.apply((C) clone());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
The result of `clone()` completely has the current clause, so there is no need to pass it to `where` again.